### PR TITLE
Replace broken docs about us link with Spatie home page.

### DIFF
--- a/resources/views/_layouts/_partials/template.blade.php
+++ b/resources/views/_layouts/_partials/template.blade.php
@@ -59,7 +59,7 @@
 <footer class="footer">
     <div class="grid">
         <div class="footer_content">
-            © {{ Date('Y') }} • <a href="about-us/">About us</a>
+            © {{ Date('Y') }} • <a href="https://spatie.be/">Spatie</a>
             • <a href="{{ $githubUrl }}">Github</a>
         </div>
     </div>


### PR DESCRIPTION
I clicked this link and it appears to not be an actual link, so I replaced with the homepage. 
