### PR TITLE
Fix link to preparing-your-model in Medialibrary introduction

### DIFF
--- a/resources/views/laravel-medialibrary/v4/introduction.md
+++ b/resources/views/laravel-medialibrary/v4/introduction.md
@@ -24,7 +24,7 @@ $newsItem->addMedia($bigFile)->toCollectionOnDisk('downloads', 's3');
 
 The storage of the files is handled by [Laravel's Filesystem](http://laravel.com/docs/5.1/filesystem),  so you can plug in any compatible filesystem.
 
-The package can also generate derived images such as thumbnails for images and pdf's. Once you've [set up your model](/laravel-medialibrary/v4/converting-images/defining-conversions/), they're easily accessible:
+The package can also generate derived images such as thumbnails for images and pdf's. Once you've [set up your model](/laravel-medialibrary/v4/basic-usage/preparing-your-model), they're easily accessible:
 
 ```php
 $newsItem->getMedia('images')->first()->getUrl('thumb');


### PR DESCRIPTION
Update Laravel Medialibrary's introduction.md so "set up your model" points to `/laravel-medialibrary/v4/basic-usage/preparing-your-model`. It was pointing to `/laravel-medialibrary/v4/converting-images/defining-conversions/`.
