### PR TITLE
Fix missing return types on medialibrary generators (url and path)

### DIFF
--- a/resources/views/laravel-medialibrary/v4/advanced-usage/generating-custom-urls.md
+++ b/resources/views/laravel-medialibrary/v4/advanced-usage/generating-custom-urls.md
@@ -4,7 +4,7 @@ title: Generating custom urls
 
 When `getUrl` is called the task of generating that URL is passed to an implementation of `Spatie\MediaLibraryUrlGenerator`.
 
-The package contains a `LocalUrlGenerator` that can generate URLs for a media library that is stored inside the public path. An `S3UrlGenerator` is also included for when you're using S3 to store your files. 
+The package contains a `LocalUrlGenerator` that can generate URLs for a media library that is stored inside the public path. An `S3UrlGenerator` is also included for when you're using S3 to store your files.
 
 If you are storing your media files in a private directory or are using a different filesystem, you can write your own `UrlGenerator`. Your generator must adhere to the `Spatie\MediaLibraryUrlGenerator` interface. If you'd extend `Spatie\MediaLibraryUrlGenerator\BaseGenerator` you only need to implement one method: `getUrl`, which should return the URL. You can call `getPathRelativeToRoot` to get the relative path to the root of your disk.
 
@@ -12,9 +12,9 @@ The code of the included `S3UrlGenerator` should help make things more clear:
 
 ```php
  namespace Spatie\MediaLibrary\UrlGenerator;
- 
+
  use Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDeterminedException;
- 
+
  class S3UrlGenerator extends BaseUrlGenerator implements UrlGenerator
  {
      /**
@@ -24,7 +24,7 @@ The code of the included `S3UrlGenerator` should help make things more clear:
       *
       * @throws UrlCouldNotBeDeterminedException
       */
-     public function getUrl()
+     public function getUrl() : string;
      {
          return config('laravel-medialibrary.s3.domain').'/'.$this->getPathRelativeToRoot();
      }

--- a/resources/views/laravel-medialibrary/v4/advanced-usage/using-a-custom-directory-structure.md
+++ b/resources/views/laravel-medialibrary/v4/advanced-usage/using-a-custom-directory-structure.md
@@ -43,7 +43,7 @@ interface PathGenerator
      *
      * @return string
      */
-    public function getPath(Media $media);
+    public function getPath(Media $media) : string;
 
     /**
      * Get the path for conversions of the given media, relative to the root storage path.
@@ -52,7 +52,7 @@ interface PathGenerator
      *
      * @return string
      */
-    public function getPathForConversions(Media $media);
+    public function getPathForConversions(Media $media) : string;
 }
 ```
 


### PR DESCRIPTION
I noticed the missing return types while implementing a custom path generator class
