### PR TITLE
Fix some typos, spelling and grammar in medialibrary v3 & v4 docs

### DIFF
--- a/resources/views/laravel-medialibrary/v3/advanced-usage/consuming-events.md
+++ b/resources/views/laravel-medialibrary/v3/advanced-usage/consuming-events.md
@@ -25,7 +25,7 @@ This event will be fired after a collection has been cleared.
 
 The event has two public properties:
 
-- `model`:  the object that conforms `\Spatie\MediaLibrary\HasMedia\Interfaces\HasMedia` of which a collection has just been cleared.
+- `model`:  the object that conforms to `\Spatie\MediaLibrary\HasMedia\Interfaces\HasMedia` of which a collection has just been cleared.
 - `collectionName`: the name of the collection that has just been cleared
 
 ## Sample usage

--- a/resources/views/laravel-medialibrary/v3/advanced-usage/generating-custom-urls.md
+++ b/resources/views/laravel-medialibrary/v3/advanced-usage/generating-custom-urls.md
@@ -2,7 +2,7 @@
 title: Generating custom urls
 ---
 
-When `getUrl` is called the task of generating that URL is passed to an implementation of `Spatie\MediaLibraryUrlGenerator`.
+When `getUrl` is called, the task of generating that URL is passed to an implementation of `Spatie\MediaLibraryUrlGenerator`.
 
 The package contains a `LocalUrlGenerator` that can generate URLs for a media library that is stored inside the public path. An `S3UrlGenerator` is also included for when you're using S3 to store your files. 
 

--- a/resources/views/laravel-medialibrary/v3/advanced-usage/using-a-custom-directory-structure.md
+++ b/resources/views/laravel-medialibrary/v3/advanced-usage/using-a-custom-directory-structure.md
@@ -59,7 +59,7 @@ interface PathGenerator
 ```
 
 [This example from the tests](https://github.com/spatie/laravel-medialibrary/blob/3.9.0/tests/PathGenerator/CustomPathGenerator.php) uses
-the md5 value of media-id to name directories. The directories were conversions are stored will be named `c` instead of the default `conversions`.
+the md5 value of media-id to name directories. The directories where conversions are stored will be named `c` instead of the default `conversions`.
 
-There aren't any restrictions on how the directories can be named. When a `Media`-object get deleted the package will delete its entire associated directory.
-So take care that every media gets it's own unique directory.
+There aren't any restrictions on how the directories can be named. When a `Media`-object gets deleted the package will delete its entire associated directory.
+So make sure that every media gets it's own unique directory.

--- a/resources/views/laravel-medialibrary/v3/advanced-usage/using-your-own-model.md
+++ b/resources/views/laravel-medialibrary/v3/advanced-usage/using-your-own-model.md
@@ -3,9 +3,9 @@ title: Using your own model
 ---
 
 A custom model can be used in version 3.4.0 and higher.
-This allows you do add your own fields, add relationships and so on.
+This allows you to add your own fields, add relationships and so on.
 
-The easiest way to use your own custom model woul be to extend the 
+The easiest way to use your own custom model would be to extend the 
 default `Spatie\MediaLibrary\Media`-class. Here's an example:
 
 ```php

--- a/resources/views/laravel-medialibrary/v3/api/adding-files.md
+++ b/resources/views/laravel-medialibrary/v3/api/adding-files.md
@@ -22,7 +22,7 @@ $yourModel
 ```php
 /**
  * Add a file to the medialibrary. The file will be removed from
- * it's original location.
+ * its original location.
  *
  * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $file
  *
@@ -122,7 +122,7 @@ This is an alias for `usingFileName`
 public function withCustomProperties(array $customProperties)
 ```
 
-##Finishing methods
+## Finishing methods
 
 ### toMediaLibrary
 

--- a/resources/views/laravel-medialibrary/v3/api/defining-conversions.md
+++ b/resources/views/laravel-medialibrary/v3/api/defining-conversions.md
@@ -6,7 +6,7 @@ A media conversion can be added to your model in the `registerModelConversions`-
 It should start with a call to `addMediaConversion`. From there on you can use any of
 the methods available in the API. They are all chainable.
 
-Look in the [Defining conversions section](/laravel-medialibrary/v3/converting-images/defining-conversions/)
+Take a look in the [Defining conversions section](/laravel-medialibrary/v3/converting-images/defining-conversions/)
 for more details.
 
 ## General methods

--- a/resources/views/laravel-medialibrary/v3/basic-usage/retrieving-media.md
+++ b/resources/views/laravel-medialibrary/v3/basic-usage/retrieving-media.md
@@ -8,9 +8,9 @@ To retrieve files you can use the `getMedia`-method:
 $mediaItems = $newsItem->getMedia();
 ```
 
-The method returns a collection with `Media`-objects.
+The method returns a collection of `Media`-objects.
 
-You can retrieve the URL and path to the file associated with `Media`-object with `getUrl` and `getPath`:
+You can retrieve the URL and path to the file associated with the `Media`-object with `getUrl` and `getPath`:
 
 ```php
 $publicUrl = $mediaItems[0]->getUrl();

--- a/resources/views/laravel-medialibrary/v3/converting-images/defining-conversions.md
+++ b/resources/views/laravel-medialibrary/v3/converting-images/defining-conversions.md
@@ -26,10 +26,10 @@ class NewsItem extends Model implements HasMediaConversions
 
 When associating a jpg-, png-, or pdf-file, the package will—besides storing the original image—create a derived image for every media conversion that was added. By default, the output will be saved as a jpg-file.
 
-Internally, [Glide](http://glide.thephpleague.com/) is used to manipulate the images. You can use any parameter from their image API. So if you want to output another image format you 
+Internally, [Glide](http://glide.thephpleague.com/) is used to manipulate the images. You can use any parameter from their image API. So if you want to output to another image format you 
 can specify png or gif using the `fm`-key in an image profile.
 
-By default, a conversion will be added to the queue that you've specified in the configuration. You can also avoid the usage of the queue by calling `nonQueued` on a conversion.
+By default, a conversion will be added to the queue that you've specified in the configuration. You can avoid the usage of the queue by calling `nonQueued` on a conversion.
 
 You can add as many conversions on a model as you'd like. Conversions can also be performed on all collections by dropping the `performOnCollections`-call, or passing "*" as the collections parameter.
 
@@ -40,7 +40,7 @@ You can add as many conversions on a model as you'd like. Conversions can also b
 
 public function registerMediaConversions()
 {
-    // Perform a resize and filter on images from the images- and anotherCollection collections
+    // Perform a resize and filter on images from the 'images' and 'anotherCollection' collections
     // and save them as png files.
     $this->addMediaConversion('thumb')
          ->setManipulations(['w' => 368, 'h' => 232, 'filt' => 'greyscale', 'fm' => 'png'])
@@ -60,7 +60,7 @@ public function registerMediaConversions()
 
 ## Convenience Methods
 
-Instead of specifying the glide parameters in the `setManipulations` method, you can also you use the built in convenience methods.
+Instead of specifying the glide parameters in the `setManipulations` method, you can also you use the built-in convenience methods.
 
 This media conversion:
 

--- a/resources/views/laravel-medialibrary/v3/converting-images/retrieving-converted-images.md
+++ b/resources/views/laravel-medialibrary/v3/converting-images/retrieving-converted-images.md
@@ -7,10 +7,10 @@ You can retrieve the URL or path to a converted image by specifiying the convers
 ```php
 $mediaItems = $newsItem->getMedia('images');
 $mediaItems[0]->getUrl('thumb');
-$mediaItems[0]->getPath('thumb'); // Absolute path on it's disk
+$mediaItems[0]->getPath('thumb'); // Absolute path on its disk
 ```
 
-Because retrieving an URL for the first media item in a collection is such a common scenario, the `getFirstMediaUrl` convenience-method is provided. The first parameter is the name of the collection, the second the name of a conversion. There's also a `getFirstMediaPath`-variant that returns the absolute path on it's disk. 
+Because retrieving an URL for the first media item in a collection is such a common scenario, the `getFirstMediaUrl` convenience-method is provided. The first parameter is the name of the collection, the second is the name of a conversion. There's also a `getFirstMediaPath`-variant that returns the absolute path on it's disk. 
 
 ```php
 $urlToFirstListImage = $newsItem->getFirstMediaUrl('images', 'thumb');

--- a/resources/views/laravel-medialibrary/v3/installation-setup.md
+++ b/resources/views/laravel-medialibrary/v3/installation-setup.md
@@ -79,7 +79,7 @@ return [
 ];
 ```
 
-Finally you should add a disk to `app/config/filesystems.php`. All files added the media library will be stored on that disk, this would be a typical configuration:
+Finally you should add a disk to `app/config/filesystems.php`. All files added to the media library will be stored on that disk, this would be a typical configuration:
 
 ```php
 return [

--- a/resources/views/laravel-medialibrary/v4/advanced-usage/consuming-events.md
+++ b/resources/views/laravel-medialibrary/v4/advanced-usage/consuming-events.md
@@ -23,7 +23,7 @@ This event will be fired after a collection has been cleared.
 
 The event has two public properties:
 
-- `model`:  the object that conforms `\Spatie\MediaLibrary\HasMedia\Interfaces\HasMedia` of which a collection has just been cleared.
+- `model`:  the object that conforms to `\Spatie\MediaLibrary\HasMedia\Interfaces\HasMedia` of which a collection has just been cleared.
 - `collectionName`: the name of the collection that has just been cleared
 
 ## Sample usage

--- a/resources/views/laravel-medialibrary/v4/advanced-usage/generating-custom-urls.md
+++ b/resources/views/laravel-medialibrary/v4/advanced-usage/generating-custom-urls.md
@@ -2,7 +2,7 @@
 title: Generating custom urls
 ---
 
-When `getUrl` is called the task of generating that URL is passed to an implementation of `Spatie\MediaLibraryUrlGenerator`.
+When `getUrl` is called, the task of generating that URL is passed to an implementation of `Spatie\MediaLibraryUrlGenerator`.
 
 The package contains a `LocalUrlGenerator` that can generate URLs for a media library that is stored inside the public path. An `S3UrlGenerator` is also included for when you're using S3 to store your files.
 

--- a/resources/views/laravel-medialibrary/v4/advanced-usage/using-a-custom-directory-structure.md
+++ b/resources/views/laravel-medialibrary/v4/advanced-usage/using-a-custom-directory-structure.md
@@ -3,8 +3,8 @@ title: Using a custom directory structure
 ---
 
 By default files will be stored inside a directory that uses
-the `id` of it's `Media`-object as a name. Converted images will be stored inside a directory
-names conversions.
+the `id` of its `Media`-object as a name. Converted images will be stored inside a directory
+named conversions.
 
 ```php
 media
@@ -57,7 +57,7 @@ interface PathGenerator
 ```
 
 [This example from the tests](https://github.com/spatie/laravel-medialibrary/blob/3.9.0/tests/PathGenerator/CustomPathGenerator.php) uses
-the md5 value of media-id to name directories. The directories were conversions are stored will be named `c` instead of the default `conversions`.
+the md5 value of media-id to name directories. The directories where conversions are stored will be named `c` instead of the default `conversions`.
 
-There aren't any restrictions on how the directories can be named. When a `Media`-object get deleted the package will delete its entire associated directory.
-So take care that every media gets it's own unique directory.
+There aren't any restrictions on how the directories can be named. When a `Media`-object gets deleted the package will delete its entire associated directory.
+So make sure that every media gets its own unique directory.

--- a/resources/views/laravel-medialibrary/v4/advanced-usage/using-your-own-model.md
+++ b/resources/views/laravel-medialibrary/v4/advanced-usage/using-your-own-model.md
@@ -3,9 +3,9 @@ title: Using your own model
 ---
 
 A custom model can be used in version 3.4.0 and higher.
-This allows you do add your own fields, add relationships and so on.
+This allows you to add your own fields, add relationships and so on.
 
-The easiest way to use your own custom model woul be to extend the 
+The easiest way to use your own custom model would be to extend the 
 default `Spatie\MediaLibrary\Media`-class. Here's an example:
 
 ```php

--- a/resources/views/laravel-medialibrary/v4/api/adding-files.md
+++ b/resources/views/laravel-medialibrary/v4/api/adding-files.md
@@ -22,7 +22,7 @@ $yourModel
 ```php
 /**
  * Add a file to the medialibrary. The file will be removed from
- * it's original location.
+ * its original location.
  *
  * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $file
  *
@@ -136,7 +136,7 @@ This is an alias for `usingFileName`
 public function withCustomProperties(array $customProperties)
 ```
 
-##Finishing methods
+## Finishing methods
 
 ### toMediaLibrary
 

--- a/resources/views/laravel-medialibrary/v4/api/defining-conversions.md
+++ b/resources/views/laravel-medialibrary/v4/api/defining-conversions.md
@@ -6,7 +6,7 @@ A media conversion can be added to your model in the `registerModelConversions`-
 It should start with a call to `addMediaConversion`. From there on you can use any of
 the methods available in the API. They are all chainable.
 
-Look in the [Defining conversions section](/laravel-medialibrary/v4/converting-images/defining-conversions/)
+Take a look in the [Defining conversions section](/laravel-medialibrary/v4/converting-images/defining-conversions/)
 for more details.
 
 ## General methods

--- a/resources/views/laravel-medialibrary/v4/basic-usage/retrieving-media.md
+++ b/resources/views/laravel-medialibrary/v4/basic-usage/retrieving-media.md
@@ -8,9 +8,9 @@ To retrieve files you can use the `getMedia`-method:
 $mediaItems = $newsItem->getMedia();
 ```
 
-The method returns a collection with `Media`-objects.
+The method returns a collection of `Media`-objects.
 
-You can retrieve the URL and path to the file associated with `Media`-object with `getUrl` and `getPath`:
+You can retrieve the URL and path to the file associated with the `Media`-object with `getUrl` and `getPath`:
 
 ```php
 $publicUrl = $mediaItems[0]->getUrl();

--- a/resources/views/laravel-medialibrary/v4/converting-images/defining-conversions.md
+++ b/resources/views/laravel-medialibrary/v4/converting-images/defining-conversions.md
@@ -26,10 +26,10 @@ class NewsItem extends Model implements HasMediaConversions
 
 When associating a jpg-, png-, or pdf-file, the package will—besides storing the original image—create a derived image for every media conversion that was added. By default, the output will be saved as a jpg-file.
 
-Internally, [Glide](http://glide.thephpleague.com/) is used to manipulate the images. You can use any parameter from their image API. So if you want to output another image format you 
-can specify png or gif using the `fm`-key in an image profile. If you specify `src` in the `fm`-key the derived image will have the same format as the original image.
+Internally, [Glide](http://glide.thephpleague.com/) is used to manipulate the images. You can use any parameter from their image API. So if you want to output to another image format you 
+can specify png or gif using the `fm`-key in an image profile. If you specify `src` in the `fm`-key, the derived image will have the same format as the original image.
 
-By default, a conversion will be added to the queue that you've specified in the configuration. You can also avoid the usage of the queue by calling `nonQueued` on a conversion.
+By default, a conversion will be added to the queue that you've specified in the configuration. You can avoid the usage of the queue by calling `nonQueued` on a conversion.
 
 You can add as many conversions on a model as you'd like. Conversions can also be performed on all collections by dropping the `performOnCollections`-call, or passing "*" as the collections parameter.
 
@@ -40,7 +40,7 @@ You can add as many conversions on a model as you'd like. Conversions can also b
 
 public function registerMediaConversions()
 {
-    // Perform a resize and filter on images from the images- and anotherCollection collections
+    // Perform a resize and filter on images from the 'images' and 'anotherCollection' collections
     // and save them as png files.
     $this->addMediaConversion('thumb')
          ->setManipulations(['w' => 368, 'h' => 232, 'filt' => 'greyscale', 'fm' => 'png'])
@@ -60,7 +60,7 @@ public function registerMediaConversions()
 
 ## Convenience Methods
 
-Instead of specifying the glide parameters in the `setManipulations` method, you can also you use the built in convenience methods.
+Instead of specifying the glide parameters in the `setManipulations` method, you can also you use the built-in convenience methods.
 
 This media conversion:
 

--- a/resources/views/laravel-medialibrary/v4/converting-images/retrieving-converted-images.md
+++ b/resources/views/laravel-medialibrary/v4/converting-images/retrieving-converted-images.md
@@ -7,10 +7,10 @@ You can retrieve the URL or path to a converted image by specifiying the convers
 ```php
 $mediaItems = $newsItem->getMedia('images');
 $mediaItems[0]->getUrl('thumb');
-$mediaItems[0]->getPath('thumb'); // Absolute path on it's disk
+$mediaItems[0]->getPath('thumb'); // Absolute path on its disk
 ```
 
-Because retrieving an URL for the first media item in a collection is such a common scenario, the `getFirstMediaUrl` convenience-method is provided. The first parameter is the name of the collection, the second the name of a conversion. There's also a `getFirstMediaPath`-variant that returns the absolute path on it's disk. 
+Because retrieving an URL for the first media item in a collection is such a common scenario, the `getFirstMediaUrl` convenience-method is provided. The first parameter is the name of the collection, the second is the name of a conversion. There's also a `getFirstMediaPath`-variant that returns the absolute path on it's disk. 
 
 ```php
 $urlToFirstListImage = $newsItem->getFirstMediaUrl('images', 'thumb');

--- a/resources/views/laravel-medialibrary/v4/installation-setup.md
+++ b/resources/views/laravel-medialibrary/v4/installation-setup.md
@@ -49,7 +49,7 @@ return [
     'max_file_size' => 1024 * 1024 * 10,
 
     /*
-     * This queue will used to generate derived images.
+     * This queue will be used to generate derived images.
      * Leave empty to use the default queue.
      */
     'queue_name' => '',
@@ -60,7 +60,7 @@ return [
     'media_model' => Spatie\MediaLibrary\Media::class,
 
     /*
-     * When urls to files get generated this class will be called. Leave empty
+     * When urls to files are generated this class will be called. Leave empty
      * if your files are stored locally above the site root or on s3.
      */
     'custom_url_generator_class' => null,
@@ -79,7 +79,7 @@ return [
 ];
 ```
 
-Finally you should add a disk to `app/config/filesystems.php`. All files added the media library will be stored on that disk, this would be a typical configuration:
+Finally you should add a disk to `app/config/filesystems.php`. All files added to the media library will be stored on that disk, this would be a typical configuration:
 
 ```php
 return [


### PR DESCRIPTION
Took some time to read the docs for medialibrary and fix some typos, spelling and grammar.

(Sadly, I did spell 'typos' wrong in my commit message, whoops :blush: )
