### PR TITLE
Fixing some typos, spelling & grammar in laravel-backup v3 docs

### DIFF
--- a/resources/views/laravel-backup/v3/advanced-usage/adding-extra-files-to-the-zip.md
+++ b/resources/views/laravel-backup/v3/advanced-usage/adding-extra-files-to-the-zip.md
@@ -2,7 +2,7 @@
 title: Adding Extra Files to the zip
 ---
 
-When performing a backup the package will create a zip file containing all files that need to be backed up together with the dumped databases.
+When performing a backup the package will create a zip file containing all files that need to be backed up and the dumped databases.
 
 Right after the zip is created and before it is copied to any of the destination filesystems the `Spatie\Backup\Events\BackupZipWasCreated`-event will be fired. This is what is looks like:
 

--- a/resources/views/laravel-backup/v3/advanced-usage/backing-up-a-non-laravel-application.md
+++ b/resources/views/laravel-backup/v3/advanced-usage/backing-up-a-non-laravel-application.md
@@ -8,4 +8,4 @@ To do so install Laravel on the same server where your non-Laravel applications 
 
 Do not forget to configure the database as well. In `app/config/databases.php` put the credentials of the database used by the non-Laravel application. 
 
-When running `php artisan backup:run` on the command line the application will be backed up.
+When running `php artisan backup:run` on the command line, the application will be backed up.

--- a/resources/views/laravel-backup/v3/cleaning-up-old-backups/events.md
+++ b/resources/views/laravel-backup/v3/cleaning-up-old-backups/events.md
@@ -21,5 +21,5 @@ This event will be fired when something goes wrong while cleaning up.
 It has two public properties:
 
 - `$exception`: an object that conforms to the `Exception`-interface. It is highly likely that `$exception->getMessage()` will return more information on what went wrong.
-- `$backupDestination`: if this is `null` then probably something went before even connecting to one of the backup destinations. If it is an instance of `Spatie\Backup\BackupDestination\BackupDestination` something went connecting or
+- `$backupDestination`: if this is `null` then probably something went wrong before even connecting to one of the backup destinations. If it is an instance of `Spatie\Backup\BackupDestination\BackupDestination` something went wrong connecting or
 writing to that destination.

--- a/resources/views/laravel-backup/v3/installation-and-setup.md
+++ b/resources/views/laravel-backup/v3/installation-and-setup.md
@@ -66,7 +66,7 @@ return [
 
             /*
              * The names of the connections to the databases that should be part of the backup.
-             * Currently only MySQL-and PostgreSQL-databases are supported.
+             * Currently only MySQL- and PostgreSQL-databases are supported.
              */
             'databases' => [
                 'mysql'
@@ -86,8 +86,8 @@ return [
 
     'cleanup' => [
         /*
-         * The strategy that will be used to cleanup old backups.
-         * The youngest backup wil never be deleted.
+         * The strategy that will be used to clean up old backups.
+         * The youngest backup will never be deleted.
          */
         'strategy' => \Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy::class,
 
@@ -224,7 +224,7 @@ Of course, the hours used in the code above are just examples. Adjust them to yo
 
 ## Monitoring
 
-When your application is broken the scheduled jobs will obviously not run anymore. You could also simply forget to add a cron job needed to trigger Laravel's scheduling. You're thinking backups are being made but in fact
+When your application is broken the scheduled jobs will obviously not run anymore. You could also simply forget to add a cron job needed to trigger Laravel's scheduling. You think backups are being made but in fact
 nothing gets backed up.
 
 To notify you of such events the package contains monitoring functionality. It will inform you when backups become too old or when they take up too much storage.
@@ -232,9 +232,9 @@ To notify you of such events the package contains monitoring functionality. It w
 Learn how to [set up monitoring](/laravel-backup/v3/monitoring-the-health-of-all-backups/overview).
 
 ## Dumping the database
-`mysqldump` and `pg_dump` are used to dump the database. If they are not installed in a default location, you can add a key named `dump_command_path` in Laravel's own `database.php` config file. Be sure to only filled in the path to the binary without the name of the binary itself.
+`mysqldump` and `pg_dump` are used to dump the database. If they are not installed in a default location, you can add a key named `dump_command_path` in Laravel's own `database.php` config file. Be sure to only fill in the path to the binary without the name of the binary itself.
 
-If your database dump takes a long time you might hit the default timeout of 60 seconds. You can set a higher (or lower) limit by providing a `dump_command_timeout` config key containing how long the command may run in seconds.
+If your database dump takes a long time you might hit the default timeout of 60 seconds. You can set a higher (or lower) limit by providing a `dump_command_timeout` config key which sets how long the command may run in seconds.
 
 Here's an example for MySQL:
 ```php

--- a/resources/views/laravel-backup/v3/monitoring-the-health-of-all-backups/overview.md
+++ b/resources/views/laravel-backup/v3/monitoring-the-health-of-all-backups/overview.md
@@ -6,7 +6,7 @@ The package can check the health of every application it is installed into. A ba
 
 ## Installation
 
-We recommend setting up a separate Laravel installation preferably on a separate server. Doing it this way will ensure you will still get notified of unhealthy backups even if one of the applications you are monitoring is broken.
+We recommend setting up a separate Laravel installation, preferably on a separate server. Doing it this way will ensure you will still get notified of unhealthy backups even if one of the applications you are monitoring is broken.
 
 To install the monitor follow the regular [installation instructions](/laravel-backup/v3/installation-and-setup).
 Instead of scheduling the `backup:run` and `backup:clean` commands, you should schedule the monitor command.

--- a/resources/views/laravel-backup/v3/taking-backups/overview.md
+++ b/resources/views/laravel-backup/v3/taking-backups/overview.md
@@ -20,7 +20,7 @@ If you only need to backup the db run:
 php artisan backup:run --only-db
 ```
 
-If you only need to backup the files, and skip dumping databases, run:
+If you only need to backup the files, and want to skip dumping databases, run:
 
 ```bash
 php artisan backup:run --only-files
@@ -89,9 +89,9 @@ This is the portion of the configuration that will determine which files and dat
     ];
 ```
 
-The specified databases will be dumped and, together with the other selected files be zipped. The zipfile will have be named `<specified name in configuration>-<YY-MM-DD:His>.zip`.
+The specified databases will be dumped and, together with the selected files, be zipped. The zipfile will have be named `<specified name in configuration>-<YY-MM-DD:His>.zip`.
  
-The more files you need to backup, the bigger the zip will become. Make sure there's enough free room on your disk to create the zip. After the zip is copied to all destinations it will be deleted.
+The more files you need to backup, the bigger the zip will become. Make sure there's enough free space on your disk to create the zip. After the zip has beens copied to all destinations it will be deleted.
  
 ### Determining the destination of the backup
 


### PR DESCRIPTION
This time I took the time to fix some errors in the laravel-backup v3 docs
