### PR TITLE
Link to sections

### DIFF
--- a/app/Markdown/Converter.php
+++ b/app/Markdown/Converter.php
@@ -2,6 +2,7 @@
 
 namespace App\Markdown;
 
+use League\CommonMark\Block\Element\Heading;
 use League\CommonMark\DocParser;
 use League\CommonMark\Environment;
 use League\CommonMark\HtmlRenderer;
@@ -11,6 +12,7 @@ class Converter
     public static function convert(string $markdown): string
     {
         $environment = Environment::createCommonMarkEnvironment();
+        $environment->addBlockRenderer(Heading::class, new HeadingRenderer());
 
         $parser = new DocParser($environment);
         $htmlRenderer = new HtmlRenderer($environment);

--- a/app/Markdown/Converter.php
+++ b/app/Markdown/Converter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Markdown;
+
+use League\CommonMark\DocParser;
+use League\CommonMark\Environment;
+use League\CommonMark\HtmlRenderer;
+
+class Converter
+{
+    public static function convert(string $markdown): string
+    {
+        $environment = Environment::createCommonMarkEnvironment();
+
+        $parser = new DocParser($environment);
+        $htmlRenderer = new HtmlRenderer($environment);
+
+        $document = $parser->parse($markdown);
+
+        return $htmlRenderer->renderBlock($document);
+    }
+}

--- a/app/Markdown/HeadingRenderer.php
+++ b/app/Markdown/HeadingRenderer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Markdown;
+
+use League\CommonMark\Block\Element\AbstractBlock;
+use League\CommonMark\Block\Renderer\HeadingRenderer as BaseHeadingRenderer;
+use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\HtmlElement;
+
+class HeadingRenderer extends BaseHeadingRenderer
+{
+    public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, $inTightList = false)
+    {
+        $element = parent::render($block, $htmlRenderer, $inTightList);
+
+        $id = str_slug($element->getContents());
+
+        $element->setAttribute('id', $id);
+        $element->setContents(
+            $element->getContents() .
+            new HtmlElement('a', ['href' => "#{$id}", 'class' => 'anchor-link'])
+        );
+
+        return $element;
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,12 +1,12 @@
 <?php
 
 use App\Http\Navigation\Navigation;
-use League\CommonMark\CommonMarkConverter;
+use App\Markdown\Converter as MarkdownConverter;
 use Spatie\Menu\Laravel\Menu;
 
 function markdown(string $markdown) : string
 {
-    return (new CommonMarkConverter())->convertToHtml($markdown);
+    return MarkdownConverter::convert($markdown);
 }
 
 function menu() : Menu

--- a/public/build/laravel-activitylog.style.css
+++ b/public/build/laravel-activitylog.style.css
@@ -461,12 +461,23 @@ table {
     border-color: #f76b6e;
     color: #a32324; }
 
-.badge {
-  background-color: rgba(206, 235, 242, 0.75);
-  border-radius: 1em;
-  color: #e14a0c;
-  display: inline-block;
-  padding: 0 .35em; }
+.anchor-link {
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  line-height: 1;
+  position: absolute;
+  right: 100%;
+  color: #e6decd !important;
+  border: none !important;
+  font-size: 1.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: normal; }
+  .anchor-link:hover {
+    color: #baab8c !important; }
+  .anchor-link:before {
+    content: '#'; }
 
 .article h1 {
   color: #1b3747;
@@ -524,6 +535,13 @@ table {
   transition: all .1s; }
   .article_badges a {
     border: 0; }
+
+.badge {
+  background-color: rgba(206, 235, 242, 0.75);
+  border-radius: 1em;
+  color: #e14a0c;
+  display: inline-block;
+  padding: 0 .35em; }
 
 html {
   height: 100%; }

--- a/public/build/laravel-activitylog.style.css
+++ b/public/build/laravel-activitylog.style.css
@@ -462,20 +462,20 @@ table {
     color: #a32324; }
 
 .anchor-link {
+  border: none !important;
+  color: #d4cab4 !important;
   display: block;
-  width: 1rem;
-  height: 1rem;
-  line-height: 1;
+  font-size: .75em;
+  font-weight: normal;
+  height: 1em;
   position: absolute;
   right: 100%;
-  color: #e6decd !important;
-  border: none !important;
-  font-size: 1.25rem;
-  top: 50%;
-  transform: translateY(-50%);
-  font-weight: normal; }
+  top: .3em;
+  width: 1em;
+  text-align: right;
+  padding-right: .5rem; }
   .anchor-link:hover {
-    color: #baab8c !important; }
+    color: #8d7e5f !important; }
   .anchor-link:before {
     content: '#'; }
 

--- a/public/build/laravel-backup.style.css
+++ b/public/build/laravel-backup.style.css
@@ -461,12 +461,23 @@ table {
     border-color: #f76b6e;
     color: #a32324; }
 
-.badge {
-  background-color: rgba(206, 235, 242, 0.75);
-  border-radius: 1em;
-  color: #e14a0c;
-  display: inline-block;
-  padding: 0 .35em; }
+.anchor-link {
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  line-height: 1;
+  position: absolute;
+  right: 100%;
+  color: #e6decd !important;
+  border: none !important;
+  font-size: 1.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: normal; }
+  .anchor-link:hover {
+    color: #baab8c !important; }
+  .anchor-link:before {
+    content: '#'; }
 
 .article h1 {
   color: #1b3747;
@@ -524,6 +535,13 @@ table {
   transition: all .1s; }
   .article_badges a {
     border: 0; }
+
+.badge {
+  background-color: rgba(206, 235, 242, 0.75);
+  border-radius: 1em;
+  color: #e14a0c;
+  display: inline-block;
+  padding: 0 .35em; }
 
 html {
   height: 100%; }

--- a/public/build/laravel-backup.style.css
+++ b/public/build/laravel-backup.style.css
@@ -462,20 +462,20 @@ table {
     color: #a32324; }
 
 .anchor-link {
+  border: none !important;
+  color: #d4cab4 !important;
   display: block;
-  width: 1rem;
-  height: 1rem;
-  line-height: 1;
+  font-size: .75em;
+  font-weight: normal;
+  height: 1em;
   position: absolute;
   right: 100%;
-  color: #e6decd !important;
-  border: none !important;
-  font-size: 1.25rem;
-  top: 50%;
-  transform: translateY(-50%);
-  font-weight: normal; }
+  top: .3em;
+  width: 1em;
+  text-align: right;
+  padding-right: .5rem; }
   .anchor-link:hover {
-    color: #baab8c !important; }
+    color: #8d7e5f !important; }
   .anchor-link:before {
     content: '#'; }
 

--- a/public/build/laravel-medialibrary.style.css
+++ b/public/build/laravel-medialibrary.style.css
@@ -461,12 +461,23 @@ table {
     border-color: #f76b6e;
     color: #a32324; }
 
-.badge {
-  background-color: rgba(206, 235, 242, 0.75);
-  border-radius: 1em;
-  color: #e14a0c;
-  display: inline-block;
-  padding: 0 .35em; }
+.anchor-link {
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  line-height: 1;
+  position: absolute;
+  right: 100%;
+  color: #e6decd !important;
+  border: none !important;
+  font-size: 1.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: normal; }
+  .anchor-link:hover {
+    color: #baab8c !important; }
+  .anchor-link:before {
+    content: '#'; }
 
 .article h1 {
   color: #1b3747;
@@ -524,6 +535,13 @@ table {
   transition: all .1s; }
   .article_badges a {
     border: 0; }
+
+.badge {
+  background-color: rgba(206, 235, 242, 0.75);
+  border-radius: 1em;
+  color: #e14a0c;
+  display: inline-block;
+  padding: 0 .35em; }
 
 html {
   height: 100%; }

--- a/public/build/laravel-medialibrary.style.css
+++ b/public/build/laravel-medialibrary.style.css
@@ -462,20 +462,20 @@ table {
     color: #a32324; }
 
 .anchor-link {
+  border: none !important;
+  color: #d4cab4 !important;
   display: block;
-  width: 1rem;
-  height: 1rem;
-  line-height: 1;
+  font-size: .75em;
+  font-weight: normal;
+  height: 1em;
   position: absolute;
   right: 100%;
-  color: #e6decd !important;
-  border: none !important;
-  font-size: 1.25rem;
-  top: 50%;
-  transform: translateY(-50%);
-  font-weight: normal; }
+  top: .3em;
+  width: 1em;
+  text-align: right;
+  padding-right: .5rem; }
   .anchor-link:hover {
-    color: #baab8c !important; }
+    color: #8d7e5f !important; }
   .anchor-link:before {
     content: '#'; }
 

--- a/public/build/menu.style.css
+++ b/public/build/menu.style.css
@@ -461,12 +461,23 @@ table {
     border-color: #f76b6e;
     color: #a32324; }
 
-.badge {
-  background-color: rgba(206, 235, 242, 0.75);
-  border-radius: 1em;
-  color: #e14a0c;
-  display: inline-block;
-  padding: 0 .35em; }
+.anchor-link {
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  line-height: 1;
+  position: absolute;
+  right: 100%;
+  color: #e6decd !important;
+  border: none !important;
+  font-size: 1.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: normal; }
+  .anchor-link:hover {
+    color: #baab8c !important; }
+  .anchor-link:before {
+    content: '#'; }
 
 .article h1 {
   color: #1b3747;
@@ -524,6 +535,13 @@ table {
   transition: all .1s; }
   .article_badges a {
     border: 0; }
+
+.badge {
+  background-color: rgba(206, 235, 242, 0.75);
+  border-radius: 1em;
+  color: #e14a0c;
+  display: inline-block;
+  padding: 0 .35em; }
 
 html {
   height: 100%; }

--- a/public/build/menu.style.css
+++ b/public/build/menu.style.css
@@ -462,20 +462,20 @@ table {
     color: #a32324; }
 
 .anchor-link {
+  border: none !important;
+  color: #d4cab4 !important;
   display: block;
-  width: 1rem;
-  height: 1rem;
-  line-height: 1;
+  font-size: .75em;
+  font-weight: normal;
+  height: 1em;
   position: absolute;
   right: 100%;
-  color: #e6decd !important;
-  border: none !important;
-  font-size: 1.25rem;
-  top: 50%;
-  transform: translateY(-50%);
-  font-weight: normal; }
+  top: .3em;
+  width: 1em;
+  text-align: right;
+  padding-right: .5rem; }
   .anchor-link:hover {
-    color: #baab8c !important; }
+    color: #8d7e5f !important; }
   .anchor-link:before {
     content: '#'; }
 

--- a/resources/assets/sass/_base/_base.scss
+++ b/resources/assets/sass/_base/_base.scss
@@ -7,8 +7,9 @@
 @import 'settings/typography';
 @import 'layout/algolia';
 @import 'layout/alert';
-@import 'layout/badge';
+@import 'layout/anchor-link';
 @import 'layout/article';
+@import 'layout/badge';
 @import 'layout/footer';
 @import 'layout/github-custom';
 @import 'layout/grid';

--- a/resources/assets/sass/_base/layout/_anchor-link.scss
+++ b/resources/assets/sass/_base/layout/_anchor-link.scss
@@ -1,0 +1,22 @@
+.anchor-link {
+  border: none !important;
+  color: color($gold, lighter) !important;
+  display: block;
+  font-size: 1.25rem;
+  font-weight: normal;
+  height: 1rem;
+  line-height: 1;
+  position: absolute;
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1rem;
+
+  &:hover {
+    color: color($gold) !important;
+  }
+
+  &:before {
+    content: '#';
+  }
+}

--- a/resources/assets/sass/_base/layout/_anchor-link.scss
+++ b/resources/assets/sass/_base/layout/_anchor-link.scss
@@ -1,19 +1,19 @@
 .anchor-link {
   border: none !important;
-  color: color($gold, lighter) !important;
+  color: color($gold, light) !important;
   display: block;
-  font-size: 1.25rem;
+  font-size: .75em;
   font-weight: normal;
-  height: 1rem;
-  line-height: 1;
+  height: 1em;
   position: absolute;
   right: 100%;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 1rem;
+  top: .3em;
+  width: 1em;
+  text-align: right;
+  padding-right: .5rem;
 
   &:hover {
-    color: color($gold) !important;
+    color: color($gold, dark) !important;
   }
 
   &:before {

--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -3,6 +3,8 @@
 @section('title', $title)
 
 @section('content')
-    <h1>{{ $title }}</h1>
+    <h1 id="{{ str_slug($title) }}">
+        {{ $title }} <a href="#{{ str_slug($title) }}" class="anchor-link"></a>
+    </h1>
     {!! $content !!}
 @endsection


### PR DESCRIPTION
**Work in progress**

I extended the CommonMark renderer to add id's to headings, and suffix them with invisible links (like GitHub does in readme files).

Html looks liks this:

``` html
<h1 id="my-title">My Title<a href="#my-title" class="anchor-link"></a></h1>
```

If the rendered html needs to be edited, it needs to happen in two places:
- `app/Markdown/HeadingRenderer.php`
- `resources/views/page.blade.php`
