### PR TITLE
Fix typo in the About Us page

### DIFF
--- a/resources/views/laravel-slack-slash-command/v1/about-us.md
+++ b/resources/views/laravel-slack-slash-command/v1/about-us.md
@@ -9,5 +9,4 @@ of the free pieces of software we use every single day. For this, we are very gr
 When we feel we have solved a problem in a way that can help other developers, 
 we release our code as open source software [on GitHub](https://spatie.be/opensource).
 
-This activitylog package was made and is maintained by [Freek Van der Herten](https://twitter.com/freekmurze) 
-and. Here's a list of [all contributors](https://github.com/spatie/laravel-slack-slash-command/graphs/contributors) as well.
+This laravel-slack-slash-command package was made and is maintained by [Freek Van der Herten](https://twitter.com/freekmurze) and. Here's a list of [all contributors](https://github.com/spatie/laravel-slack-slash-command/graphs/contributors) as well.


### PR DESCRIPTION
Change package name from **activitylog** to **laravel-slack-slash-command**
