### PR TITLE
Fixed a typo in laravel-slack-slash-command installation and setup page

### DIFF
--- a/resources/views/laravel-slack-slash-command/v1/installation-and-setup.md
+++ b/resources/views/laravel-slack-slash-command/v1/installation-and-setup.md
@@ -21,7 +21,7 @@ These are things you'll need to do:
 The package can be installed in your Laravel app via composer:
 
 ``` bash
-composer require spatie/laravel-slash-slack-command
+composer require spatie/laravel-slack-slash-command
 ```
 
 Next, you must install the service provider:


### PR DESCRIPTION
Hello @freekmurze, how are  you?

I'm a little embarrassed to fix such a minor thing, but I'm pretty sure this issue was caused by that typo: spatie/laravel-slack-slash-command#8

This typo is also present in your blog post: https://murze.be/2016/07/building-a-slack-bot-with-laravel/

I stumbled upon this after copying and pasting the name of the package and receiving "Could not find package" response from composer.

Thank you,
Álvaro.
