### PR TITLE
Cleaned up public_path() method usage in installation docs

### DIFF
--- a/resources/views/laravel-medialibrary/v3/installation-setup.md
+++ b/resources/views/laravel-medialibrary/v3/installation-setup.md
@@ -87,7 +87,7 @@ return [
     'disks' => [
         'media' => [
             'driver' => 'local',
-            'root'   => public_path().'/media',
+            'root'   => public_path('media'),
         ],
     ... 
 ];   

--- a/resources/views/laravel-medialibrary/v4/installation-setup-in-laravel.md
+++ b/resources/views/laravel-medialibrary/v4/installation-setup-in-laravel.md
@@ -87,7 +87,7 @@ return [
     'disks' => [
         'media' => [
             'driver' => 'local',
-            'root'   => public_path().'/media',
+            'root'   => public_path('media'),
         ],
     ... 
 ];   


### PR DESCRIPTION
Cleaned up public_path() method usage in installation docs, both v3 and v4
