### PR TITLE
Update installation-and-setup.md

### DIFF
--- a/resources/views/laravel-backup/v4/installation-and-setup.md
+++ b/resources/views/laravel-backup/v4/installation-and-setup.md
@@ -228,14 +228,14 @@ To find out about problems with your backups, the package ships with monitoring 
 Learn how to [set up monitoring](/laravel-backup/v4/monitoring-the-health-of-all-backups/overview).
 
 ## Dumping the database
-`mysqldump` and `pg_dump` are used to dump the database. If they are not installed in a default location, you can add a key named `dump_command_path` in Laravel's own `database.php` config file. **Only fill in the path to the binary**. Do not include the name of the binary itself.
+`mysqldump` and `pg_dump` are used to dump the database. If they are not installed in a default location, you can add a key named `dump.dump_binary_path` in Laravel's own `database.php` config file. **Only fill in the path to the binary**. Do not include the name of the binary itself.
 
-If your database dump takes a long time, you might exceed the default timeout of 60 seconds. You can set a higher (or lower) limit by providing a `dump_command_timeout` config key which specifies, in seconds, how long the command may run.
+If your database dump takes a long time, you might exceed the default timeout of 60 seconds. You can set a higher (or lower) limit by providing a `dump.timeout` config key which specifies, in seconds, how long the command may run.
 
 Here's an example for MySQL:
 
 ```php
-//config/databases.php
+//config/database.php
 'connections' => [
 	'mysql' => [
 		'driver'    => 'mysql'
@@ -243,7 +243,7 @@ Here's an example for MySQL:
 		'dump' => [
 		   'dump_binary_path' => '/path/to/the/binary', // only the path, so without `mysqldump` or `pg_dump`
 		   'use_single_transaction',
-		   'timeout' => 5,
+		   'timeout' => 60 * 5, // 5 minute timeout
 		   'exclude_tables' => ['table1', 'table2'],
 		   'add_extra_option' => '--optionname=optionvalue', 
 		]  


### PR DESCRIPTION
Fixes database.php filename. Updates the names of the `dump` keys. Provides an example of 60*5 (5 minute timeout) for the timeout.