### PR TITLE
describe how to override the default filesystem class

### DIFF
--- a/resources/views/laravel-medialibrary/v4/advanced-usage/overriding-default-filesystem-behavior.md
+++ b/resources/views/laravel-medialibrary/v4/advanced-usage/overriding-default-filesystem-behavior.md
@@ -1,0 +1,21 @@
+---
+title: Overriding the default filesystem behavior
+---
+
+The `Spatie\MediaLibrary\Filesystem` class contains the behavior for actions like adding files, renaming files and deleting files. It applies these actions to the disks (local, S3, etc) that you configured.
+
+If you want to override the default behavior you can create your own Filesystem implementation by implementing `Spatie\MediaLibrary\FilesystemInterface`. You then bind your own class to the service container in the AppServiceProvider:
+
+```php
+use App\CustomFilesystem;
+use Spatie\MediaLibrary\FilesystemInterface;
+ 
+class AppServiceProvider extends ServiceProvider
+{
+    ...
+    public function register()
+    {
+        $this->app->bind(FilesystemInterface::class, CustomFilesystem::class);
+    }
+}
+```


### PR DESCRIPTION
Added a description of how to override the default Filesystem class.

See https://github.com/spatie/laravel-medialibrary/pull/466 for the added funtionality.