### PR TITLE
Fix incorrect urlgenerator class names in medialibrary v4 docs

### DIFF
--- a/resources/views/laravel-medialibrary/v4/advanced-usage/generating-custom-urls.md
+++ b/resources/views/laravel-medialibrary/v4/advanced-usage/generating-custom-urls.md
@@ -2,11 +2,11 @@
 title: Generating custom urls
 ---
 
-When `getUrl` is called, the task of generating that URL is passed to an implementation of `Spatie\MediaLibraryUrlGenerator`.
+When `getUrl` is called, the task of generating that URL is passed to an implementation of `Spatie\MediaLibrary\UrlGenerator`.
 
 The package contains a `LocalUrlGenerator` that can generate URLs for a media library that is stored inside the public path. An `S3UrlGenerator` is also included for when you're using S3 to store your files.
 
-If you are storing your media files in a private directory or are using a different filesystem, you can write your own `UrlGenerator`. Your generator must adhere to the `Spatie\MediaLibraryUrlGenerator` interface. If you'd extend `Spatie\MediaLibraryUrlGenerator\BaseGenerator` you only need to implement one method: `getUrl`, which should return the URL. You can call `getPathRelativeToRoot` to get the relative path to the root of your disk.
+If you are storing your media files in a private directory or are using a different filesystem, you can write your own `UrlGenerator`. Your generator must adhere to the `Spatie\MediaLibrary\UrlGenerator` interface. If you'd extend `Spatie\MediaLibrary\UrlGenerator\BaseUrlGenerator` you only need to implement one method: `getUrl`, which should return the URL. You can call `getPathRelativeToRoot` to get the relative path to the root of your disk.
 
 The code of the included `S3UrlGenerator` should help make things more clear:
 


### PR DESCRIPTION
This PR fixes some invalid naming in the documentation of medialibrary v4.

These problems were discovered in this issue: https://github.com/spatie/laravel-medialibrary/issues/400