### PR TITLE
Fix #114

### DIFF
--- a/resources/assets/sass/home/home.scss
+++ b/resources/assets/sass/home/home.scss
@@ -1,7 +1,6 @@
 @import '../_base/base';
 
 .header {
-  overflow: hidden;
   background-color: color($blue, darkest);
 }
 


### PR DESCRIPTION
Using the chrome developer tools I found the bug for this and found a fix. 

The reason for the bug is that the `.header class` is `overflow: hidden` and the version picker gets longer than its parent which is the `.header` class