### PR TITLE
This should be .jpg or?

### DIFF
--- a/resources/views/image/v1/introduction.md
+++ b/resources/views/image/v1/introduction.md
@@ -50,7 +50,7 @@ Image::load('github-logo.png')
     ->fit(Manipulations::FIT_FILL, 500, 300)
     ->background('lightblue')
     ->border(15, '007698', Manipulations::BORDER_EXPAND)
-    ->save('example.png');
+    ->save('example.jpg');
 ```
 
 ![Example PNG to JPG](https://docs.spatie.be/images/image/example-png-to-jpg.jpg)


### PR DESCRIPTION
As said in the Text ("The image is converted to PNG simply by saving it with the correct file extension.") This should be .jpg not .png (because the Title is "Converting a transparent PNG to JPG")