### PR TITLE
Add note about mysql credentials for backup package

### DIFF
--- a/resources/views/laravel-backup/v3/installation-and-setup.md
+++ b/resources/views/laravel-backup/v3/installation-and-setup.md
@@ -261,3 +261,5 @@ Here's an example for MySQL:
 ```
 
 For PostgreSQL db's you can also set a config key named `dump_use_inserts` to use `inserts` instead of `copy` in the database dump file.
+
+If `mysqldump` fails with a `1045: Access denied for user` error please make sure your MySql credentials are correct and do not contain any PHP [escape sequences](http://php.net/manual/en/language.types.string.php#language.types.string.syntax.double) (for example `\n` or `\r`).


### PR DESCRIPTION
Escape sequences in mysql credentials can lead to `mysqldump: Got error: 1045: Access denied for user`