### PR TITLE
Update retrieving-media.md

### DIFF
--- a/resources/views/laravel-medialibrary/v5/basic-usage/retrieving-media.md
+++ b/resources/views/laravel-medialibrary/v5/basic-usage/retrieving-media.md
@@ -10,6 +10,12 @@ $mediaItems = $newsItem->getMedia();
 
 The method returns a collection of `Media`-objects.
 
+By default, `getMedia` looks for all media items accosiated with a collection with name `default`. To retrieve files from a different collection, specify the collection name in method's arguments:
+
+```php
+$mediaItems = $newsItem->getMedia('collectionName');
+```
+
 You can retrieve the url and path to the file associated with the `Media`-object using  `getUrl` and `getPath`:
 
 ```php


### PR DESCRIPTION
getMedia (which calls `getCollection()` which, in turn, invokes `loadMedia()` ) may accept the name of the collection. If collection name is not specified and the user has used a collection with name !== `default`, the getMedia fails silently and returns an empty collection