### PR TITLE
Nginx example updated

### DIFF
--- a/resources/views/laravel-server-monitor/v1/monitoring-basics/writing-your-own-checks.md
+++ b/resources/views/laravel-server-monitor/v1/monitoring-basics/writing-your-own-checks.md
@@ -24,7 +24,7 @@ class Nginx extends CheckDefinition
 
     public function resolve(Process $process)
     {
-        if ($process->getOutput() == 'active') {
+        if (trim($process->getOutput()) == 'active') {
             $this->check->succeed('is running');
 
             return;

--- a/resources/views/laravel-server-monitor/v1/monitoring-basics/writing-your-own-checks.md
+++ b/resources/views/laravel-server-monitor/v1/monitoring-basics/writing-your-own-checks.md
@@ -24,7 +24,7 @@ class Nginx extends CheckDefinition
 
     public function resolve(Process $process)
     {
-        if (str_contains($process->getOutput(), 'active')) {
+        if ($process->getOutput() == 'active') {
             $this->check->succeed('is running');
 
             return;


### PR DESCRIPTION
The output of `systemctl is-active nginx` is `active` when nginx-process is running or `inactive` when the process is not running. The current example leads to a false positive. I have updated the resolve() function to check if the process output is equal to `active`.