### PR TITLE
Specify MySQL version

### DIFF
--- a/resources/views/laravel-tags/v1/requirements.md
+++ b/resources/views/laravel-tags/v1/requirements.md
@@ -2,4 +2,4 @@
 title: Requirements
 ---
 
-This package requires Laravel 5.3 or higher, PHP 7.0 or higher and a database that supports `json` fields such as MySQL 5.7 or higher.
+This package requires Laravel 5.3 or higher, PHP 7.0 or higher and a database that supports `json` fields such as MySQL 5.7.8 or higher.


### PR DESCRIPTION
It's a bit pedantic, but the JSON field type wasn't introduced until 5.7.8.