### PR TITLE
Rename config file to medialibrary.php

### DIFF
--- a/resources/views/laravel-medialibrary/v5/advanced-usage/using-your-own-model.md
+++ b/resources/views/laravel-medialibrary/v5/advanced-usage/using-your-own-model.md
@@ -19,7 +19,7 @@ class Media extends BaseMedia
 In the config file of the package you must specify the name of your custom class:
 
 ```php
-// config/laravel-medialibrary.php
+// config/medialibrary.php
 ...
    'media_model' => App\Models\CustomMedia::class
 ...


### PR DESCRIPTION
In version 5, the config file is renamed from `laravel-medialibrary.php` to `medialibrary.php`.