### PR TITLE
Update regenerating-images.md

### DIFF
--- a/resources/views/laravel-medialibrary/v5/converting-images/regenerating-images.md
+++ b/resources/views/laravel-medialibrary/v5/converting-images/regenerating-images.md
@@ -11,5 +11,5 @@ $ php artisan medialibrary:regenerate
 If you only want to regenerate the images for a single model, you can specify it as a parameter:
 
 ```bash
-$ php artisan medialibrary:regenerate news
+$ php artisan medialibrary:regenerate "App\Post"
 ```


### PR DESCRIPTION
I don't believe there will be a real world scenario where someone's model_type is 'news' (plural + all lowercase). Mine defaults to App\{Model} so I think this can be better reflected on this particular doc page. 

It's a small change but it might save someone searching in the source for the correct parameter syntax (like I did).