### PR TITLE
Remove spatie specific slack url

### DIFF
--- a/resources/views/laravel-slack-slash-command/v1/installation-and-setup.md
+++ b/resources/views/laravel-slack-slash-command/v1/installation-and-setup.md
@@ -5,7 +5,7 @@ title: Installation and Setup
 ## Setting up a slash command at Slack.com
 
 In order to use this package you'll need to setup a slash command. Head over to the [custom integrations page
-at slack.com](https://spatie.slack.com/apps/manage/custom-integrations) to get started. There click "slash commands" and on the next page click "Add configuration". On that screen you can choose a name for your Slack command. You can choose anything that Slack allows. And finally you can setup your new command.
+at slack.com](https://slack.com/apps/manage/custom-integrations) to get started. There click "slash commands" and on the next page click "Add configuration". On that screen you can choose a name for your Slack command. You can choose anything that Slack allows. And finally you can setup your new command.
 
 You should now be on a screen that looks like this.
 


### PR DESCRIPTION
The previous url points to the spatie specific slack page, prompting the documentation reader with a login form. The non spatie version will redirect the reader either to their slack integrations or to slacks auth flow.