### PR TITLE
Make config publish snippet consistent with description

### DIFF
--- a/resources/views/laravel-server-monitor/v1/installation-and-setup.md
+++ b/resources/views/laravel-server-monitor/v1/installation-and-setup.md
@@ -37,7 +37,7 @@ php artisan migrate
 To publish the config file to `config/server-monitor.php` run:
 
 ``` bash
-php artisan vendor:publish --provider="Spatie\ServerMonitor\ServerMonitorServiceProvider"
+php artisan vendor:publish --provider="Spatie\ServerMonitor\ServerMonitorServiceProvider" --tag="config"
 ```
 
 By default, the configuration looks like this:


### PR DESCRIPTION
The publish snippet for the config was missing the `--tag` option, resulting publishing both config and migration.