### PR TITLE
Point to correct versions in introduction

### DIFF
--- a/resources/views/laravel-backup/v5/introduction.md
+++ b/resources/views/laravel-backup/v5/introduction.md
@@ -16,12 +16,12 @@ In addition to making the backup, the package can also clean up old backups, mon
 
 ## Using an older version of PHP / Laravel ?
 
-If you're not on PHP 7 or Laravel 5.3 just use version 3 of this package. 
+If you're not on PHP 7 or Laravel 5.5 just use version 3 of this package. 
  
 Just issue this command:
 
 ```php
-composer require "spatie/laravel-backup:^5.0.0"
+composer require "spatie/laravel-backup:^3.0.0"
 ```
 
 Read the extensive [documentation on version 3](https://docs.spatie.be/laravel-backup/v3) to learn how to set up and use the package.


### PR DESCRIPTION
The introductions mentions you can use v3 if you're on an older version of PHP/Laravel but shows how to require the current version (5). Also the requirements mentionen 5.5 while this page mentiones 5.3, so I also updated that.