### PR TITLE
fixes conversion syntax for "sharpen"

### DIFF
--- a/resources/views/laravel-medialibrary/v6/converting-images/defining-conversions.md
+++ b/resources/views/laravel-medialibrary/v6/converting-images/defining-conversions.md
@@ -63,7 +63,7 @@ use Spatie\Image\Manipulations;
         $this->addMediaConversion('thumb')
               ->width(368)
               ->height(232)
-              ->sharpen;
+              ->sharpen(10);
 
         $this->addMediaConversion('old-picture')
               ->sepia()


### PR DESCRIPTION
fixes `->sharpen()` syntax on documentation page.