### PR TITLE
Replace laravel-backup.php with backup.php (v5)

### DIFF
--- a/resources/views/laravel-backup/v5/advanced-usage/backing-up-a-non-laravel-application.md
+++ b/resources/views/laravel-backup/v5/advanced-usage/backing-up-a-non-laravel-application.md
@@ -4,7 +4,7 @@ title: Backing up a non-laravel application
 
 This package is tailor-made for use inside Laravel applications. But with a little bit of good will you can use it to backup non-Laravel applications as well.
  
-To do so install Laravel on the same server where your non-Laravel application runs. In the Laravel app you'll have to install this package using the [installation instructions](/laravel-backup/v5/installation-and-setup). In the `app/config/laravel-backup.php`configuration file specify the paths of the non-laravel application you wish to backup in the `backup.source.files.include` key.
+To do so install Laravel on the same server where your non-Laravel application runs. In the Laravel app you'll have to install this package using the [installation instructions](/laravel-backup/v5/installation-and-setup). In the `app/config/backup.php`configuration file specify the paths of the non-laravel application you wish to backup in the `backup.source.files.include` key.
 
 Do not forget to configure the database as well. In `app/config/databases.php` put the credentials of the database used by the non-Laravel application. 
 

--- a/resources/views/laravel-backup/v5/cleaning-up-old-backups/overview.md
+++ b/resources/views/laravel-backup/v5/cleaning-up-old-backups/overview.md
@@ -17,7 +17,7 @@ We'll tell you right off the bat that the package by default will never delete t
 This portion of the configuration determines which backups should be deleted.
 
 ```php
-//config/laravel-backup.php
+//config/backup.php
 
     'cleanup' => [
         /*

--- a/resources/views/laravel-backup/v5/installation-and-setup.md
+++ b/resources/views/laravel-backup/v5/installation-and-setup.md
@@ -12,7 +12,7 @@ composer require spatie/laravel-backup
 
 The package will automatically register it's service provider.
 
-To publish the config file to `config/laravel-backup.php` run:
+To publish the config file to `config/backup.php` run:
 
 ``` bash
 php artisan vendor:publish --provider="Spatie\Backup\BackupServiceProvider"

--- a/resources/views/laravel-backup/v5/sending-notifications/adding-extra-notification-channels.md
+++ b/resources/views/laravel-backup/v5/sending-notifications/adding-extra-notification-channels.md
@@ -47,7 +47,7 @@ class BackupHasFailed extends BaseNotification
 The last thing you need to do is register your custom notification in the config file.
 
 ```php
-// config/laravel-backup.php
+// config/backup.php
 use \NotificationChannels\PusherPushNotifications\Channel as PusherChannel
 
 ...

--- a/resources/views/laravel-backup/v5/sending-notifications/overview.md
+++ b/resources/views/laravel-backup/v5/sending-notifications/overview.md
@@ -9,7 +9,7 @@ The package leverages Laravel 5.3's native notifications to let you know that yo
 This is the portion of the configuration that will determine when and how notifications will be sent.
 
 ```php
-//config/laravel-backup.php
+//config/backup.php
 
     /*
      * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.


### PR DESCRIPTION
I upgraded from v4 to v5 and forgot to rename `laravel-backup.php` to `backup.php`, because docs were inconsistend. This pull request should fix this :)