### PR TITLE
Update laravel uptime monitor docs

### DIFF
--- a/app/Http/Navigation/laravel-uptime-monitor-v3.php
+++ b/app/Http/Navigation/laravel-uptime-monitor-v3.php
@@ -33,5 +33,6 @@ return [
         'Disabling monitors',
         'Using your own model',
         'Monitoring from multiple locations',
+        'Sending and verifying a payload',
     ],
 ];

--- a/resources/views/laravel-uptime-monitor/v3/advanced-usage/manually-modifying-monitors.md
+++ b/resources/views/laravel-uptime-monitor/v3/advanced-usage/manually-modifying-monitors.md
@@ -3,21 +3,23 @@ title: Manually modifying monitors
 ---
 
 All configured monitors are stored in the `monitors` table in the database. The various `monitor` commands manipulate the data that table:
- 
+
  - `monitor:create` adds a row
  - `monitor:delete` deletes a row
  - `monitor:enable` and `monitor:disable` change the value of the `enabled` field
  - `monitor:list` lists all rows
  - `monitor:sync-file` syncs monitors from a json file (see [syncing monitors from a file](https://docs.spatie.be/laravel-uptime-monitor/v3/advanced-usage/syncing-monitors-from-a-file))
- 
+
 You can also manually manipulate the table rows instead. Here's a description of the fields you can manipulate:
- 
+
  - `url`: the url to perform uptime and ssl certificate checks on. Take care not to insert duplicate values.
  - `uptime_check_enabled`: determines if the uptime check should be performed for this monitor.
  - `certificate_check_enabled`: determines if the ssl certificate check should be performed for this monitor.
  - `look_for_string`: if this string is not found in the response the uptime check will fail. You may set this to an empty string to disable the check.
  - `uptime_check_interval_in_minutes`: if the uptime check was successful that site won't be checked again for at least this number of minutes. When a monitor is created this field is filled with the value of `uptime_check_interval_in_minutes` in the config file.
  - `uptime_check_get_method`: the `http` method used by the uptime check. If `look_for_string` is specified when creating the monitor this will be set to `get`, otherwise this will be `head`.
+ - `uptime_check_payload`: a payload that will be sent as the monitor request body. If you are using this field, you should set the `Content-Type` header in the `uptime_check_additional_headers` field.
+ - `uptime_check_additional_headers`: additional headers that are sent in the request. The value shoule be escaped `JSON`. It will be decoded using `json_decode`. Example: `{"Content-Type":"application\/json"}`
+ - `uptime_check_response_checker`: the fully qualified class name of a custom response checker that will be used only for this monitor. It must be an implementation of `Spatie\UptimeMonitor\Helpers\UptimeResponseCheckers\UptimeResponseChecker` and will be resolved using the [service container](https://laravel.com/docs/5.5/container).
 
  All other fields in the `monitors` table are managed by the package and should not be manually modified.
- 

--- a/resources/views/laravel-uptime-monitor/v3/advanced-usage/sending-and-verifying-a-payload.md
+++ b/resources/views/laravel-uptime-monitor/v3/advanced-usage/sending-and-verifying-a-payload.md
@@ -1,0 +1,50 @@
+---
+title: Sending and verifying a payload
+---
+
+There are cases in which you would like to send a payload and verify the response to determine if is services is up and active for example, if you need to detrerming if a down stream service is connected and functioning correctly.
+
+To achieve this you will need to manually update a few fields in the database and optionally create a custom response checker specifically for that monitor to verify the response from the uptime monitor request.
+
+In this example, you will need to set the following fields in the database:
+
+- `uptime_check_get_method`: `POST`
+ - `uptime_check_payload`: `{"foo":"bar","baz":true}`
+ - `uptime_check_additional_headers`: `{"Content-Type":"application\/json","Authorization":"Bearer NbMXe2NkzNex0Om9ERD89gXQRq6YZLMrpLQ6tX58uajEkHLEe2EbkY1oB9VJXYwZ"}`
+ - `uptime_check_response_checker`: `App\ResponseCheckers\ExampleChecker`
+
+ _More details on these fields can be found in the section "[Manually Modifying Monitors](/laravel-uptime-monitor/v3/advanced-usage/manually-modifying-monitors)"_
+
+We will want to do some custom verification specifically for the response of this check.
+
+Our checker could look something like the following:
+
+```php
+<?php
+
+namespace App\ResponseCheckers;
+
+use Illuminate\Http\Response;
+use Psr\Http\Message\ResponseInterface;
+use Spatie\UptimeMonitor\Models\Monitor;
+use Spatie\UptimeMonitor\Helpers\UptimeResponseCheckers\UptimeResponseChecker;
+
+class ExampleChecker implements UptimeResponseChecker
+{
+    public function isValidResponse(ResponseInterface $response, Mon
+    {
+        return $response->getStatusCode() === Response::HTTP_OK
+            && (json_decode($body, true))['foo'] === 'bar'
+    }
+
+    public function getFailureReason(ResponseInterface $response, Monitor $monitor) : string
+    {
+        return vsprintf('Foo returned %s instead of bar with a status code of %s', [
+            json_decode($response->getBody(), true)['foo'],
+            $response->getStatusCode(),
+        ]);
+    }
+}
+```
+
+This workflow is extremely flexible and should allow for some pretty advanced uptime and monitoring checks.


### PR DESCRIPTION
* Adds documentation relevant to https://github.com/spatie/laravel-uptime-monitor/pull/131 & https://github.com/spatie/laravel-uptime-monitor/pull/127
* Adds an additional section explaining how to send an verify a custom monitor payload.