### PR TITLE
fix typo error on classname on custom modal name

### DIFF
--- a/resources/views/laravel-medialibrary/v6/advanced-usage/using-your-own-model.md
+++ b/resources/views/laravel-medialibrary/v6/advanced-usage/using-your-own-model.md
@@ -11,7 +11,7 @@ default `Spatie\MediaLibrary\Media`-class. Here's an example:
 namespace App\Models;
 use Spatie\MediaLibrary\Media as BaseMedia;
 
-class Media extends BaseMedia 
+class CustomMedia extends BaseMedia 
 {
 ...
 ```


### PR DESCRIPTION
fix typo error on classname on custom modal name