### PR TITLE
Updated the correct composer version

### DIFF
--- a/resources/views/laravel-backup/v4/installation-and-setup.md
+++ b/resources/views/laravel-backup/v4/installation-and-setup.md
@@ -7,7 +7,7 @@ title: Installation and setup
 You can install this package via composer using:
 
 ``` bash
-composer require spatie/laravel-backup
+composer require "spatie/laravel-backup:^4.0.0"
 ```
 
 You'll need to register the service provider:


### PR DESCRIPTION
When using v4, a user needs to explicitly tell composer to bring in the most recent version from the 4 branch, rather than v5.