### PR TITLE
$logName has to be static

### DIFF
--- a/resources/views/laravel-activitylog/v2/advanced-usage/logging-model-events.md
+++ b/resources/views/laravel-activitylog/v2/advanced-usage/logging-model-events.md
@@ -146,7 +146,7 @@ class NewsItem extends Model
 {
     use LogsActivity;
 
-    protected $logName = 'system';
+    protected static $logName = 'system';
 }
 ```
 


### PR DESCRIPTION
As far as I tested correct use case is:

`protected static $logName`

not 

`protected $logName`