### PR TITLE
Fix wrong method name to retrieve media-library URLs

### DIFF
--- a/resources/views/laravel-medialibrary/v7/working-with-media-collections/defining-media-collections.md
+++ b/resources/views/laravel-medialibrary/v7/working-with-media-collections/defining-media-collections.md
@@ -98,7 +98,7 @@ The first time you add a file to the collection it will be stored as usual.
 ```php
 $yourModel->add($pathToImage)->toMediaCollection('avatar');
 $yourModel->getMedia('avatar')->count(); // returns 1
-$yourModel->getFirstUrl('avatar'); // will return an url to the `$pathToImage` file
+$yourModel->getFirstMediaUrl('avatar'); // will return an url to the `$pathToImage` file
 ```
 
 When adding another file to a single file collection the first one will be deleted.
@@ -107,7 +107,7 @@ When adding another file to a single file collection the first one will be delet
 // this will remove other files in the collection
 $yourModel->add($anotherPathToImage)->toMediaCollection('avatar');
 $yourModel->getMedia('avatar')->count(); // returns 1
-$yourModel->getFirstUrl('avatar'); // will return an url to the `$anotherPathToImage` file
+$yourModel->getFirstMediaUrl('avatar'); // will return an url to the `$anotherPathToImage` file
 ```
 
 ## Registering media conversions


### PR DESCRIPTION
Hey guys,

I noticed that the documentation mentions the wrong method name to retrieve media URLs in the "single image" example.