### PR TITLE
Change custom_path_generator_class to path_generator

### DIFF
--- a/resources/views/laravel-medialibrary/v7/advanced-usage/using-a-custom-directory-structure.md
+++ b/resources/views/laravel-medialibrary/v7/advanced-usage/using-a-custom-directory-structure.md
@@ -23,7 +23,7 @@ media
 
 Putting files inside their own folders guarantees that files with the same name can be added without any problems.
 
-To override this default folder structure, a class that conforms to the `PathGenerator`-interface can be specified as the `custom_path_generator_class` in the config file.
+To override this default folder structure, a class that conforms to the `PathGenerator`-interface can be specified as the `path_generator` in the config file.
 
 Let's take a look at the interface:
 


### PR DESCRIPTION
In https://github.com/spatie/laravel-medialibrary/pull/937 the config parameter `custom_path_generator_class` was renamed to `path_generator`