### PR TITLE
Fix parsing of directory structure

### DIFF
--- a/resources/views/laravel-medialibrary/v3/advanced-usage/using-a-custom-directory-structure.md
+++ b/resources/views/laravel-medialibrary/v3/advanced-usage/using-a-custom-directory-structure.md
@@ -8,7 +8,7 @@ By default files will be stored inside a directory that uses
 the `id` of it's `Media`-object as a name. Converted images will be stored inside a directory
 names conversions.
 
-```php
+```
 media
 --- 1
 ------ file.jpg

--- a/resources/views/laravel-medialibrary/v4/advanced-usage/using-a-custom-directory-structure.md
+++ b/resources/views/laravel-medialibrary/v4/advanced-usage/using-a-custom-directory-structure.md
@@ -6,7 +6,7 @@ By default files will be stored inside a directory that uses
 the `id` of its `Media`-object as a name. Converted images will be stored inside a directory
 named conversions.
 
-```php
+```
 media
 --- 1
 ------ file.jpg

--- a/resources/views/laravel-medialibrary/v5/advanced-usage/using-a-custom-directory-structure.md
+++ b/resources/views/laravel-medialibrary/v5/advanced-usage/using-a-custom-directory-structure.md
@@ -4,7 +4,7 @@ title: Using a custom directory structure
 
 By default, files will be stored inside a directory that uses the `id` of its `Media`-object as a name. Converted images will be stored inside a directory named `conversions`.
 
-```php
+```
 media
 --- 1
 ------ file.jpg

--- a/resources/views/laravel-medialibrary/v6/advanced-usage/using-a-custom-directory-structure.md
+++ b/resources/views/laravel-medialibrary/v6/advanced-usage/using-a-custom-directory-structure.md
@@ -4,7 +4,7 @@ title: Using a custom directory structure
 
 By default, files will be stored inside a directory that uses the `id` of its `Media`-object as a name. Converted images will be stored inside a directory named `conversions`.
 
-```php
+```
 media
 --- 1
 ------ file.jpg

--- a/resources/views/laravel-medialibrary/v7/advanced-usage/using-a-custom-directory-structure.md
+++ b/resources/views/laravel-medialibrary/v7/advanced-usage/using-a-custom-directory-structure.md
@@ -4,7 +4,7 @@ title: Using a custom directory structure
 
 By default, files will be stored inside a directory that uses the `id` of its `Media`-object as a name. Converted images will be stored inside a directory named `conversions`.
 
-```php
+```
 media
 --- 1
 ------ file.jpg


### PR DESCRIPTION
This prevents the numeric directory names from being parsed

<img width="875" alt="schermafbeelding 2018-04-04 om 16 39 29" src="https://user-images.githubusercontent.com/15680337/38314867-8964f712-3827-11e8-9f13-a6d72b939a7e.png">
