### PR TITLE
Update "Using your own model" docs section

### DIFF
--- a/resources/views/laravel-tags/v2/advanced-usage/using-your-own-tag-model.md
+++ b/resources/views/laravel-tags/v2/advanced-usage/using-your-own-tag-model.md
@@ -2,7 +2,7 @@
 title: Using your own tag model
 ---
 
-You might want to override some functionality of the `Spatie\Tags\Tag` or add some extra functions. It's very easy to use your own custom tag model. All you need to do is override the `getTagClassName` method from the `HasTags` trait. It should return the fully qualified class name of an eloquent model that extends `Spatie\Tags\Tag`.
+You might want to override some functionality of the `Spatie\Tags\Tag` or add some extra functions. It's very easy to use your own custom tag model. All you need to do is override the `getTagClassName` method from the `HasTags` trait. It should return the fully qualified class name of an eloquent model that extends `Spatie\Tags\Tag` and uses the same `tags` table.
 
 ```php
 use Illuminate\Database\Eloquent\Model;
@@ -13,5 +13,16 @@ class YourModel extends Model
    {
        return YourTagModel::class;
    }
+}
+```
+
+Then you need to override the `tags()` method from the same trait to tell Laravel that it still needs to look for `tags_id` column for tags relation instead of `your_tag_model_id`:
+
+```
+public function tags(): MorphToMany
+{
+        return $this
+            ->morphToMany(self::getTagClassName(), 'taggable', 'taggables', null, 'tag_id')
+            ->orderBy('order_column');
 }
 ```


### PR DESCRIPTION
It seems that previous version of doc didn't have enough information to use own models for tagging.

See [this issue](https://github.com/spatie/laravel-tags/issues/107)