### PR TITLE
Update retrieving-media.md with full media url

### DIFF
--- a/resources/views/laravel-medialibrary/v7/basic-usage/retrieving-media.md
+++ b/resources/views/laravel-medialibrary/v7/basic-usage/retrieving-media.md
@@ -14,6 +14,7 @@ You can retrieve the url and path to the file associated with the `Media`-object
 
 ```php
 $publicUrl = $mediaItems[0]->getUrl();
+$publicFullUrl = $mediaItems[0]->getFullUrl(); //url including domain
 $fullPathOnDisk = $mediaItems[0]->getPath();
 $temporaryS3Url = $mediaItems[0]->getTemporaryUrl(Carbon::now()->addMinutes(5));
 ```


### PR DESCRIPTION
Added `getFullUrl` command. Retrieves the entire url of the file, including domain.
https://github.com/spatie/laravel-medialibrary/issues/1097