### PR TITLE
Fixed some typos...

### DIFF
--- a/resources/views/laravel-event-projector/v1/advanced-usage/rebuilding-a-projector.md
+++ b/resources/views/laravel-event-projector/v1/advanced-usage/rebuilding-a-projector.md
@@ -2,11 +2,11 @@
 title: Rebuilding a projector
 ---
 
-When replaying events a projector will only receive events is has not handled yet. If you want to build up the state of a projector again from scratch, you can rebuild it.
+When replaying events, a projector will only receive events it has not handled yet. If you want to build up the state of a projector again from scratch, you can rebuild it.
 
 ## Preparing your projector
 
-In order to make your projector rebuildable you have to add a `resetState` to it. In this method you'll have to perform the work necessary to clean up the state of your projector. When rebuilding the projector we will call this method. If for instance, your projector is backed by an Eloquent model, you can truncate that model.
+In order to make your projector rebuildable, you have to add a `resetState` to it. In this method you'll have to perform the work necessary to clean up the state of your projector. When rebuilding the projector, we will call this method. If for instance, your projector is backed by an Eloquent model, you can truncate that model.
 
 ```php
 namespace App\Projectors;
@@ -35,7 +35,7 @@ php artisan event-projector:rebuild App\\Projectors\\AccountBalanceProjector
 
 This will call the `resetState` method on the projector and replay all events.
 
-You can also rebuild multipe projectors in one go:
+You can also rebuild multiple projectors in one go:
 
 ```bash
 php artisan event-projector:rebuild App\\Projectors\\AccountBalanceProjector App\Projectors\AnotherProjector
@@ -51,7 +51,7 @@ You can also remove all state from a projector but not replay events with this c
 php artisan event-projector:reset App\\Projectors\\AccountBalanceProjector
 ```
 
-You can also reset multipe projectors in one go:
+You can also reset multiple projectors in one go:
 
 ```bash
 php artisan event-projector:reset App\\Projectors\\AccountBalanceProjector App\Projectors\AnotherProjector
@@ -59,7 +59,7 @@ php artisan event-projector:reset App\\Projectors\\AccountBalanceProjector App\P
 
 ## Resetting your projector via code
 
-You can also reset a projector with code.
+You can also reset a projector with code:
 
 ```php
 use Spatie\EventProjector\Facades\EventProjectionist;

--- a/resources/views/laravel-event-projector/v1/advanced-usage/storing-metadata.md
+++ b/resources/views/laravel-event-projector/v1/advanced-usage/storing-metadata.md
@@ -2,7 +2,7 @@
 title: Storing metadata
 ---
 
-You can add meta data, such as the id of the logged in user, to a stored event. The `StoredEvent` instance will be passed on the any projector method that has a variable named `$storedEvent`. On that `StoredEvent` instance there a property `meta_data` that returns an instance of `Spatie\SchemalessAttributes\SchemalessAttributes`. 
+You can add metadata, such as the id of the logged-in user, to a stored event. The `StoredEvent` instance will be passed on to any projector method that has a variable named `$storedEvent`. On that `StoredEvent` instance there is a property, `meta_data`, that returns an instance of `Spatie\SchemalessAttributes\SchemalessAttributes`.
 
 Here's an example:
 
@@ -15,7 +15,7 @@ use Spatie\EventProjector\Projectors\ProjectsEvents;
 class MetaDataProjector implements Projector
 {
     use ProjectsEvents;
-    
+
     /*
      * Here you can specify which event should trigger which method.
      */
@@ -26,7 +26,7 @@ class MetaDataProjector implements Projector
     public function onAnyEvent(StoredEvent $storedEvent)
     {
         $storedEvent->meta_data->user_id = auth()->user()->id;
-        
+
         $storedEvent->save();
     }
 }

--- a/resources/views/laravel-event-projector/v1/advanced-usage/using-your-own-event-storage-model.md
+++ b/resources/views/laravel-event-projector/v1/advanced-usage/using-your-own-event-storage-model.md
@@ -2,4 +2,4 @@
 title: Using your own event storage model
 ---
 
-The default model responsable for storing events is `\Spatie\EventProjector\Models\StoredEvent`. If you want to add behaviour to that model you can create a class of your own that extends the `StoredEvent` model. You should but the class name of your model in the `stored_event_model` in the `event-projector.php` config file.
+The default model responsible for storing events is `\Spatie\EventProjector\Models\StoredEvent`. If you want to add behaviour to that model you can create a class of your own that extends the `StoredEvent` model. You should put the class name of your model in the `stored_event_model` in the `event-projector.php` config file.

--- a/resources/views/laravel-event-projector/v1/basic-usage/handling-side-effects-using-reactors.md
+++ b/resources/views/laravel-event-projector/v1/basic-usage/handling-side-effects-using-reactors.md
@@ -10,7 +10,7 @@ A reactor is a class, that much like a projector, listens for incoming events. U
 
 ## Creating your first reactor
 
-Let's create your first reactor. You can perform `php artisan make:reactor BigAmountAddedReactor` to create a projector in `app\Reactors`. We will make this reactor send a mail to the director of the bank whenever a a big amount of money is added to an account.
+Let's create your first reactor. You can perform `php artisan make:reactor BigAmountAddedReactor` to create a reactor in `app\Reactors`. We will make this reactor send a mail to the director of the bank whenever a big amount of money is added to an account.
 
 ```php
 namespace App\Reactors;

--- a/resources/views/laravel-event-projector/v1/basic-usage/making-sure-events-get-handled-in-the-right-order.md
+++ b/resources/views/laravel-event-projector/v1/basic-usage/making-sure-events-get-handled-in-the-right-order.md
@@ -4,7 +4,7 @@ title: Making sure events get handled in the right order
 
 In a production environment multiple events will start to come in concurrently. A queue is used to guarantee that all events get passed to projectors in the right order. You should make sure that the queue will process only one job at a time. You can set the name of the queue connection in the `queue` key of the `event-projector` config file.
 
-In a local environment, where events have a very low change of getting fired concurrently, it's probably ok to just use the `sync` driver.
+In a local environment, where events have a very low chance of getting fired concurrently, it's probably ok to just use the `sync` driver.
 
 ## Handling events immediately
 

--- a/resources/views/laravel-event-projector/v1/basic-usage/writing-your-first-projector.md
+++ b/resources/views/laravel-event-projector/v1/basic-usage/writing-your-first-projector.md
@@ -4,7 +4,7 @@ title: Writing your first projector
 
 In this section you'll learn how to write a projector. A projector is simply a class that does some work when it hears some events come in. Typically it writes data (to the database or to a file on disk). We call that written data a projection.
 
-Imagine you are a bank with customers that have accounts. All these accounts have a balance. When money gets added or subtracted we could modify the balance. If we do that however, we would never know why the balance got to that number. If we were to store all the events we could calculate the balance. 
+Imagine you are a bank with customers that have accounts. All these accounts have a balance. When money gets added or subtracted we could modify the balance. If we do that however, we would never know why the balance got to that number. If we were to store all the events we could calculate the balance.
 
 ## Creating a model
 
@@ -50,14 +50,14 @@ class Account extends Model
     public function addMoney(int $amount)
     {
         event(new MoneyAdded($this->id, $amount));
-        
+
         return $this;
     }
 
     public function subtractMoney(int $amount)
     {
         event(new MoneySubtracted($this->id, $amount));
-        
+
         return $this;
     }
 
@@ -70,7 +70,7 @@ class Account extends Model
 
 ## Defining events
 
-Instead of calculating the balance we're simply firing off events. All these events should implement `\Spatie\EventProjector\ShouldBeStored`. This is an empty interface that signifies to our package that the event should be stored.
+Instead of calculating the balance, we're simply firing off events. All these events should implement `\Spatie\EventProjector\ShouldBeStored`. This is an empty interface that signifies to our package that the event should be stored.
 
 Let's take a look at all events used in the `Account` model.
 
@@ -171,7 +171,7 @@ use Spatie\EventProjector\Projectors\ProjectsEvents;
 class AccountBalanceProjector implements Projector
 {
     use ProjectsEvents;
-    
+
     /*
      * Here you can specify which event should trigger which method.
      */
@@ -248,13 +248,13 @@ $account->subtractMoney(50);
 ...
 ```
 
-If you take a look at the contents of the `accounts` table you should see some accounts together with their calculated balance. Sweet! In the `stored_events` you should see an entry per event that we fired. 
+If you take a look at the contents of the `accounts` table you should see some accounts together with their calculated balance. Sweet! In the `stored_events` table you should see an entry per event that we fired.
 
 ## Your second projector
 
-Imagine that after a while someone at the bank wants to know which accounts have processed the most transactions. Because we stored all changes to the accounts in the events table we can easily get that info by creating another projector. 
+Imagine that after a while someone at the bank wants to know which accounts have processed the most transactions. Because we stored all changes to the accounts in the events table we can easily get that info by creating another projector.
 
-We are going to create another projector that stores the transaction count per account in a model. Bare in mind that you can easily use any other storage mechanism instead of a model. The projector doesn't care what you use.
+We are going to create another projector that stores the transaction count per account in a model. Bear in mind that you can easily use any other storage mechanism instead of a model. The projector doesn't care what you use.
 
 Here's the migration and the model class that the projector is going to use:
 
@@ -288,7 +288,7 @@ class TransactionCount extends Model
 }
 ```
 
-And here's the projector that is going to listen to the `MoneyAdded` and `MoneySubtracted` events
+And here's the projector that is going to listen to the `MoneyAdded` and `MoneySubtracted` events:
 
 ```php
 namespace App\Projectors;
@@ -335,13 +335,13 @@ Let's not forget to register this projector:
 EventProjectionist::addProjector(TransactionCountProjector::class)
 ```
 
-If you've followed along you've already created some accounts and some events. To feed those past events to the projector we can simply perform this artisan command:
+If you've followed along, you've already created some accounts and some events. To feed those past events to the projector we can simply perform this artisan command:
 
 ```php
 php artisan event-projector:replay
 ```
 
-This command will take all events stored in the `stored_events` table and pass them to  `TransactionCountProjector`. After the command completes you should see the transaction counts in the `transaction_counts` table.
+This command will take all events stored in the `stored_events` table and pass them to `TransactionCountProjector`. After the command completes you should see the transaction counts in the `transaction_counts` table.
 
 ## Welcoming new events
 
@@ -364,7 +364,6 @@ You'll notice that both projectors are doing their jobs. The balance of the `Acc
 
 ## Benefits of projectors and projections
 
-The cool thing of projectors is that you can write them after events have happened. Imagine that someone at the bank wants to have a report of the average balance of each account. You would be able to write a new projector, replay all events and have that data.
+The cool thing about projectors is that you can write them after events have happened. Imagine that someone at the bank wants to have a report of the average balance of each account. You would be able to write a new projector, replay all events, and have that data.
 
 Projections are very fast to query. Image that our application has processed millions of events. If you want to create a screen where you display the accounts with the most transactions you can easily query the `transaction_counts` table. This way you don't need to fire off some expensive query. The projector will keep the projections (the `transaction_counts` table) up to date.
-

--- a/resources/views/laravel-event-projector/v1/handling-events/handling-exceptions.md
+++ b/resources/views/laravel-event-projector/v1/handling-events/handling-exceptions.md
@@ -2,18 +2,18 @@
 title: Handling exceptions
 ---
 
-The `event-projector` config file has a key `catch_exceptions` that determines what will happen should a projector or reactor throw an exception. If this setting is set to `false` exceptions will not be catched and your app will come to a grinding halt.
+The `event-projector` config file has a key, `catch_exceptions`, that determines what will happen should a projector or reactor throw an exception. If this setting is set to `false`, exceptions will not be caught and your app will come to a grinding halt.
 
-If `catch_exceptions` is set to `true`, and an projector or reactor throws and exception, all other projectors and reactors will still get called. The `EventProjectionist` will catch all exceptions and fire the `EventHandlerFailedHandlingEvent`. That event contains these public properties:
+If `catch_exceptions` is set to `true`, and an projector or reactor throws an exception, all other projectors and reactors will still get called. The `EventProjectionist` will catch all exceptions and fire the `EventHandlerFailedHandlingEvent`. That event contains these public properties:
 
-- `eventHandler`: the projector or reactor that could not handle the event
-- `storedEvent`: the instance of `Spatie\EventProjector\Models\StoredEvent` that could not be handled.
-- `exception`: the exception thrown by the eventHandler
+- `eventHandler`: The projector or reactor that could not handle the event.
+- `storedEvent`: The instance of `Spatie\EventProjector\Models\StoredEvent` that could not be handled.
+- `exception`: The exception thrown by the `EventHandler`.
 
-It will also call the `handleException` method on the projector or reactor that threw the exception. It will receive the thrown error as the first argument. If you throw an exception in `handleException` the `EventProjectionist` will not catch it and your php process will fail.
+It will also call the `handleException` method on the projector or reactor that threw the exception. It will receive the thrown error as the first argument. If you throw an exception in `handleException`, the `EventProjectionist` will not catch it and your php process will fail.
 
 ## Getting projectors up to date again
 
-The `EventProjectionist` [keeps track](https://docs.spatie.be/laravel-event-projector/v1/replaying-events/tracking-handled-events) of which events are handled by which projectors. If a projector throws an exception the `EventHandler` will concluded that the given event was not handled.
+The `EventProjectionist` [keeps track](https://docs.spatie.be/laravel-event-projector/v1/replaying-events/tracking-handled-events) of which events are handled by which projectors. If a projector throws an exception the `EventHandler` will conclude that the given event was not handled.
 
-Because the projector is not up to date anymore new events for this projector will not be passed to it. To get your projector back up to date you should, after you've fixed the cause of the exception, [replay events](https://docs.spatie.be/laravel-event-projector/v1/replaying-events/replaying-events).
+Because the projector is not up to date anymore, new events for this projector will not be passed to it. To get your projector back up to date you should, after you've fixed the cause of the exception, [replay events](https://docs.spatie.be/laravel-event-projector/v1/replaying-events/replaying-events).

--- a/resources/views/laravel-event-projector/v1/handling-events/preparing-events.md
+++ b/resources/views/laravel-event-projector/v1/handling-events/preparing-events.md
@@ -34,6 +34,6 @@ class MoneyAdded implements ShouldBeStored
 }
 ```
 
-Whenever an event that implements `ShouldBeStored` is fired it will be serialized and written in the `stored_events` table. Immediately after that the event will be passed to all projectors and reactors.
+Whenever an event that implements `ShouldBeStored` is fired it will be serialized and written in the `stored_events` table. Immediately after that, the event will be passed to all projectors and reactors.
 
-If your event has an eloquent model it should also use the `Illuminate\Queue\SerializesModels` trait so we are able to serialize these models correctly.
+If your event has an eloquent model, it should also use the `Illuminate\Queue\SerializesModels` trait so we are able to serialize these models correctly.

--- a/resources/views/laravel-event-projector/v1/handling-events/using-projectors.md
+++ b/resources/views/laravel-event-projector/v1/handling-events/using-projectors.md
@@ -6,7 +6,7 @@ A projector is a class that listens for events that were stored. When it hears a
 
 ## Creating projectors
 
-Let's create a projector. You can perform this artisan command to create a projector in `app\Projectors`.
+Let's create a projector. You can perform this artisan command to create a projector in `app\Projectors`:
 
 ```php
 php artisan make:projector AccountBalanceProjector
@@ -16,7 +16,7 @@ php artisan make:projector AccountBalanceProjector
 
 Projectors can be registered in the `projectors` key of the `event-projectors` config file.
 
-Alternatively you can add them to the `EventProjectionist`. This can be done anywhere, but typically you would do this in an ServiceProvider of your own.
+Alternatively, you can add them to the `EventProjectionist`. This can be done anywhere, but typically you would do this in a ServiceProvider of your own.
 
 ```php
 namespace App\Providers;
@@ -31,7 +31,7 @@ class EventProjectorServiceProvider extends ServiceProvider
     {
         // adding a single projector
         EventProjectionist::addProjector(AccountBalanceProjector::class);
-        
+
         // you can also add multiple projectors in one go
         EventProjectionist::addProjectors([
             AnotherProjector::class,
@@ -43,7 +43,7 @@ class EventProjectorServiceProvider extends ServiceProvider
 
 ## Using projectors
 
-This is the contents of class created by the artisan command mentioned in the section above.
+This is the contents of a class created by the artisan command mentioned in the section above.
 
 ```php
 namespace App\Projectors;
@@ -73,7 +73,7 @@ class AccountBalanceProjector implements Projector
 
 The `$handlesEvents` property is an array which has event class names as keys and method names as values. Whenever an event is fired that matches one of the keys in `$handlesEvents` the corresponding method will be fired. You can name your methods however you like.
 
-Here's an example where we listen for a `MoneyAdded`
+Here's an example where we listen for a `MoneyAdded` event:
 
 ```php
 namespace App\Projectors;
@@ -86,13 +86,13 @@ use Spatie\EventProjector\Projectors\ProjectsEvents;
 class AccountBalanceProjector implements Projector
 {
     use ProjectsEvents;
-    
+
     /*
      * Here you can specify which event should trigger which method.
      */
     protected $handlesEvents = [
         MoneyAdded::class => 'onMoneyAdded',
-      
+
     ];
 
     public function onMoneyAdded(MoneyAdded $event)
@@ -102,15 +102,15 @@ class AccountBalanceProjector implements Projector
 }
 ```
 
-This projector will be created using the container so you may inject any depedency you'd like. In fact all methods present in `$handlesEvent` can make use of method injection, so you can resolve any depencies you need in those methods as well. Any variable in the method signature with the name `$event` will receive the event you're listening for.
+This projector will be created using the container so you may inject any dependency you'd like. In fact, all methods present in `$handlesEvent` can make use of method injection, so you can resolve any dependencies you need in those methods as well. Any variable in the method signature with the name `$event` will receive the event you're listening for.
 
 You can also use `*` as the key in the `$handlesEvents` event array. This will pass all events to the corresponding method.
 
 ## Performing some work before and after replaying events
 
-When [replaying events](/laravel-event-projector/v1/replaying-events/replaying-events) projectors will get called to.
+When [replaying events](/laravel-event-projector/v1/replaying-events/replaying-events) projectors will get called, too.
 
-If your projector has a `onStartingEventReplay` method it will get called right before the first event will be replayed. This can be handy to clean up any data your projector writes to. Here's an example were we truncate the `accounts` table before replaying events.
+If your projector has a `onStartingEventReplay` method, it will get called right before the first event will be replayed. This can be handy to clean up any data your projector writes to. Here's an example where we truncate the `accounts` table before replaying events:
 
 ```php
 namespace App\Projectors;
@@ -132,7 +132,7 @@ class AccountBalanceProjector implements Projector
 }
 ```
 
-After all events are replayed, the `onFinishedEventReplay` mehtod will be called, should your projector have one.
+After all events are replayed, the `onFinishedEventReplay` method will be called, should your projector have one.
 
 ## Naming projectors
 

--- a/resources/views/laravel-event-projector/v1/handling-events/using-reactors.md
+++ b/resources/views/laravel-event-projector/v1/handling-events/using-reactors.md
@@ -2,11 +2,11 @@
 title: Using reactors
 ---
 
-A reactor is a class, that much like a projector, listens for incoming events. Unlike projectors however, reactors will not get called when events are replayed. Reactors only will get called when the original event fires.
+A reactor is a class, that much like a projector, listens for incoming events. Unlike projectors however, reactors will not get called when events are replayed. Reactors will only get called when the original event fires.
 
-## Creating reactor
+## Creating reactors
 
-Let's create a reactor. You can perform this artisan command to create a projector in `app\Reactors`.
+Let's create a reactor. You can perform this artisan command to create a projector in `app\Reactors`:
 
 ```php
 php artisan make:reactor BigAmountAddedReactor
@@ -16,7 +16,7 @@ php artisan make:reactor BigAmountAddedReactor
 
 Reactors can be registered in the `reactors` key of the `event-projectors` config file.
 
-Alternatively they can be added to the `EventProjectionist`. This can be done anywhere, but typically you would do this in an ServiceProvider of your own.
+Alternatively, they can be added to the `EventProjectionist`. This can be done anywhere, but typically you would do this in a ServiceProvider of your own.
 
 ```php
 namespace App\Providers;
@@ -31,7 +31,7 @@ class EventProjectorServiceProvider extends ServiceProvider
     {
         // adding a single reactor
         EventProjectionist::addReactor(BigAmountAddedReactor::class);
-        
+
         // you can also add multiple reactors in one go
         EventProjectionist::addReactors([
             AnotherReactor::class,
@@ -43,7 +43,7 @@ class EventProjectorServiceProvider extends ServiceProvider
 
 ## Using reactors
 
-This is the contents of class created by the artisan command mentioned in the section above.
+This is the contents of a class created by the artisan command mentioned in the section above:
 
 ```php
 namespace App\Reactors;
@@ -68,7 +68,7 @@ class BigAmountAddedReactor
 
 The `$handlesEvents` property is an array which has event class names as keys and method names as values. Whenever an event is fired that matches one of the keys in `$handlesEvents` the corresponding method will be fired. You can name your methods however you like.
 
-Here's an example where we listen for a `MoneyAddedEvent`
+Here's an example where we listen for a `MoneyAdded` event:
 
 ```php
 namespace App\Reactors;
@@ -82,7 +82,7 @@ class BigAmountAddedReactor
      */
     protected $handlesEvents = [
         MoneyAdded::class => 'onMoneyAdded',
-      
+
     ];
 
     public function onAccountCreated(MoneyAdded $event)
@@ -92,4 +92,4 @@ class BigAmountAddedReactor
 }
 ```
 
-This reactor will be created using the container so you may inject any depedency you'd like. In fact all methods present in `$handlesEvent` can make use of method injection, so you can resolve any depencies you need in those methods as well. Any variable in the method signature with the name `$event` will receive the event you're listening for.
+This reactor will be created using the container so you may inject any dependency you'd like. In fact, all methods present in `$handlesEvent` can make use of method injection, so you can resolve any dependencies you need in those methods as well. Any variable in the method signature with the name `$event` will receive the event you're listening for.

--- a/resources/views/laravel-event-projector/v1/installation-setup.md
+++ b/resources/views/laravel-event-projector/v1/installation-setup.md
@@ -97,6 +97,4 @@ return [
 
 ```
 
-Finally you should set up a queue. Specify the connection name in `queue` key of the `event-projector` config file. This queue will be used to guarantee that the events will be processed by all projectors in the right order. You should make sure that the queue will process only one job at a time. In a local environment, where events have a very low change of getting fired concurrently, it's probably ok to just use the `sync` driver.
-
-
+Finally you should set up a queue. Specify the connection name in the `queue` key of the `event-projector` config file. This queue will be used to guarantee that the events will be processed by all projectors in the right order. You should make sure that the queue will process only one job at a time. In a local environment, where events have a very low chance of getting fired concurrently, it's probably ok to just use the `sync` driver.

--- a/resources/views/laravel-event-projector/v1/replaying-events/replaying-events.md
+++ b/resources/views/laravel-event-projector/v1/replaying-events/replaying-events.md
@@ -2,45 +2,44 @@
 title: Replaying events
 ---
 
-All [events](/laravel-event-projector/v1/handling-events/preparing-events) thats implement `Spatie\EventProjector\ShouldBeStored` will be [serialized](https://docs.spatie.be/laravel-event-projector/v1/advanced-usage/using-your-own-event-serializer) and stored in the `stored_events` table. After your app has been doing its work for a while the `stored_events` table will probably contain some events.
- 
+All [events](/laravel-event-projector/v1/handling-events/preparing-events) that implement `Spatie\EventProjector\ShouldBeStored` will be [serialized](https://docs.spatie.be/laravel-event-projector/v1/advanced-usage/using-your-own-event-serializer) and stored in the `stored_events` table. After your app has been doing its work for a while the `stored_events` table will probably contain some events.
+
  When creating a new [projector](/laravel-event-projector/v1/handling-events/using-projectors) or [reactor](/laravel-event-projector/v1/handling-events/using-reactors) you'll want to feed all stored events to that new projector or reactor. We call this process replaying events.
- 
+
  Events can be replayed to [all projectors that were added to the projectionist](/laravel-event-projector/v1/handling-events/using-reactors) with this artisan command:
- 
+
  ```bash
  php artisan event-projector:replay
  ```
- 
-The package [keeps track of which events were already passed to a projector](https://docs.spatie.be/laravel-event-projector/v1/replaying-events/tracking-handled-events). It will never pass an event that a projector already handled. So it's generally save to replay events. Only projectors that didn't handle all events yet will get called. Projectors that already handled all past events will not be called.
- 
+
+The package [keeps track of which events were already passed to a projector](https://docs.spatie.be/laravel-event-projector/v1/replaying-events/tracking-handled-events). It will never pass an event that a projector already handled. So it's generally safe to replay events. Only projectors that didn't handle all events yet will get called. Projectors that already handled all past events will not be called.
+
  You can also handpick a projectors by using the `--projector` option. All stored events will be passed only to that projector.
- 
+
  ```bash
   php artisan event-projector:replay --projector=App\\Projectors\\AccountBalanceProjector
  ```
- 
+
  You can use the projector option multiple times:
- 
+
   ```bash
    php artisan event-projector:replay --projector=App\\Projectors\\AccountBalanceProjector --projector=App\\Projectors\\AnotherProjector
   ```
-  
+
 ## Detecting event replays
 
-If your projector contains a `onStartingEventReplay` method, we'll call it right before the first event is replayed.
+If your projector contains an `onStartingEventReplay` method, we'll call it right before the first event is replayed.
 
-If it contains a `onFinishedEventReplay` we'll call it right after all events have been replayed.
+If it contains an `onFinishedEventReplay` method, we'll call it right after all events have been replayed.
 
 You can also detect the start and end of event replay by listening for the `Spatie\EventProjector\Events\StartingEventReplay` and `Spatie\EventProjector\Events\FinishedEventReplay` events.
 
-Though under normal cicurmstance you don't need to know this, you can detect if events are currently being replayed like this:
+Though, under normal circumstances, you don't need to know this, you can detect if events are currently being replayed like this:
 
 ```php
 Spatie\EventProjector\Facades\EventProjectionist::isReplayingEvents(); // returns a boolean
 ```
-  
+
 ## What about reactors?
 
-Reactors are used to handle side effects, like sending mails and such. You'll only want reactor to do their work when an event is originally fired. You don't want to send out mails when replaying events. That's why reactors will never get called when replaying events.  
-  
+Reactors are used to handle side effects, like sending mails and such. You'll only want reactors to do their work when an event is originally fired. You don't want to send out mails when replaying events. That's why reactors will never get called when replaying events.  

--- a/resources/views/laravel-event-projector/v1/replaying-events/tracking-handled-events.md
+++ b/resources/views/laravel-event-projector/v1/replaying-events/tracking-handled-events.md
@@ -2,16 +2,16 @@
 title: Tracking handled events
 ---
 
-The package keeps track of which events were already passed to which projectors. When replaying events it will never pass an event to a projector that already handled it. 
+The package keeps track of which events were already passed to which projectors. When replaying events it will never pass an event to a projector that already handled it.
 
-The `projector_statuses` table contains info on what is the status of each projector. It contains these fields:
+The `projector_statuses` table contains info on each projector's status. It contains these fields:
 
-- `name`: The fully qualified class name of your projector
-- `last_processed_event_id`: The id of the last event that was handled by this projector
+- `name`: The fully qualified class name of your projector.
+- `last_processed_event_id`: The id of the last event that was handled by this projector.
 
 ## Naming projectors
 
-By default the fully qualified class name of the projector will get used in the `name` column of the `projector_statuses` table. You can customize that name by putting a `$name` property on your projector. 
+By default the fully qualified class name of the projector will get used in the `name` column of the `projector_statuses` table. You can customize that name by putting a `$name` property on your projector.
 
 If you haven't set a `$name` on your projector, and if you'd change the fully qualified class name of your projector, you should manually update the `name` of the corresponding record in the `projector_statuses` table.
 
@@ -26,15 +26,15 @@ php artisan event-projector:list
 Here's some example output:
 ![output of list command](/images/event-projector/list-command.png)
 
-*It pains us too that the right side of the table isn't placed correctly. This is probably caused by the usage of an emoji character in the table. We have that this little bug will get solved soon in Symfony*
+*It pains us, too, that the right side of the table isn't placed correctly. This is probably caused by the usage of an emoji character in the table. We hope that this little bug will get solved soon in Symfony*
 
-The `Up to date` column will contain a green checkmark if the last processed it of that projector is equal the latest (and greatest) id in the `stored_events` table.
+The `Up to date` column will contain a green checkmark if the last processed id of that projector is equal the latest (and greatest) id in the `stored_events` table.
 
 ## When to replay events
 
 We'll only pass an event to a projector if its `id` is equal to the `last_processed_event_id` of that projector + 1. If the event id is lower than that we will not the pass the event to the projector.  When this happens we'll also fire the `Spatie\EventProjector\EventsProjectorDidNotHandlePriorEvents` event. It contains two public properties:
 
-- `$projector`: an instance of `Spatie\EventProjector\Projectors\Projector`
-- `$storedEvent`: an instance of `\Spatie\EventProjector\Models\StoredEvent`. You can get to the event that was fired like this `$storedEvent->event`
- 
+- `$projector`: An instance of `Spatie\EventProjector\Projectors\Projector`.
+- `$storedEvent`: An instance of `\Spatie\EventProjector\Models\StoredEvent`. You can get to the event that was fired like this `$storedEvent->event`.
+
  To get a projector back up to date you should [replay events](/laravel-event-projector/v1/replaying-events/replaying-events).


### PR DESCRIPTION
I finally started to take a look at the `laravel-event-projector` package and, while reading through the docs, noticed a small handful of (spelling, grammar, punctuation, and consistency) typos.  I figured I'd take a quick run through and try to find/fix what I saw.

Most are pretty obvious, I think, and some might be a little nit-picky for such documents  :-), but if anyone has any questions, please don't hesitate to let me know.