### PR TITLE
Updated docs for laravel-event-projector to reflect change in how handlesEvents is processed

### DIFF
--- a/resources/views/laravel-event-projector/v1/basic-usage/writing-your-first-projector.md
+++ b/resources/views/laravel-event-projector/v1/basic-usage/writing-your-first-projector.md
@@ -176,13 +176,16 @@ class AccountBalanceProjector implements Projector
     use ProjectsEvents;
 
     /*
-     * Here you can specify which event should trigger which method.
+     * Here you can specify which event should trigger which method. Associative
+     * entries are explicit, but one can also use non-associative entries. If a
+     * non-associative entry is used, the method will be automagically
+     * determined by prepending the event class basename with `on`.
      */
     protected $handlesEvents = [
         AccountCreated::class => 'onAccountCreated',
         MoneyAdded::class => 'onMoneyAdded',
         MoneySubtracted::class => 'onMoneySubtracted',
-        AccountDeleted::class => 'onAccountDeleted',
+        AccountDeleted::class, // Non-associative means method called will be onAccountDeleted
     ];
 
     public function onAccountCreated(AccountCreated $event)


### PR DESCRIPTION
This is related to the following change in `laravel-event-projector`: https://github.com/spatie/laravel-event-projector/pull/36

I extended a comment in the example showing a projector and it's `$handlesEvents` property.  Additionally, I changed one of the elements to point out how a non-associative element/declaration will be handled.

Feedback welcomed...!  :-)