### PR TITLE
Fix Typo in method name on BigAmountAddedReactor

### DIFF
--- a/resources/views/laravel-event-projector/v1/handling-events/using-reactors.md
+++ b/resources/views/laravel-event-projector/v1/handling-events/using-reactors.md
@@ -85,7 +85,7 @@ class BigAmountAddedReactor
 
     ];
 
-    public function onAccountCreated(MoneyAdded $event)
+    public function onMoneyAdded(MoneyAdded $event)
     {
         // do some work
     }


### PR DESCRIPTION
On the `BigAmountAddedReactor` class, the method shoud be `onMoneyAdded` not `onAccountCreated` right!?