### PR TITLE
Small fixes in "Thinking in events"

### DIFF
--- a/resources/views/laravel-event-projector/v1/basic-usage/thinking-in-events.md
+++ b/resources/views/laravel-event-projector/v1/basic-usage/thinking-in-events.md
@@ -50,7 +50,7 @@ class BrokeReactor implements EventHandler
 }
 ```
 
-A mail will get sent when an account is broken. The problem with this approach is that mails will also get sent for accounts that were already broke before. If you want to only sent mail when an account went from a positive balance to a negative balance we need to do some more work.
+A mail will get sent when an account is broke. The problem with this approach is that mails will also get sent for accounts that were already broke before. If you want to only sent mail when an account went from a positive balance to a negative balance we need to do some more work.
 
 You might be tempted to add some kind of flag here that determines if the mail was already sent.
 
@@ -75,7 +75,7 @@ class BrokeReactor implements EventHandler
         $account = Account::uuid($event->accountUuid);
 
         /*
-         * Don't send a mail if an account isn't broken
+         * Don't send a mail if an account isn't broke
          */
         if (! $account->isBroke()) {
             return;
@@ -124,11 +124,11 @@ class AccountBalanceProjector implements Projector
 
         /*
          * If the balance is above zero again, set the broke_mail_sent
-         * flag tofalse again, so we can send another mail
+         * flag to false again, so we can send another mail
          * when the balance goes below zero again.
          */
         if ($account->balance >= 0) {
-            $this->broke_mail_sent = false;
+            $account->broke_mail_sent = false;
         }
 
         $account->save();

--- a/resources/views/laravel-event-projector/v1/basic-usage/using-event-streams.md
+++ b/resources/views/laravel-event-projector/v1/basic-usage/using-event-streams.md
@@ -6,7 +6,7 @@ If your application receives a lot of concurrent requests, it will result in a l
 
 Imagine that there are many requests coming in at the same time that each want to add money to 100 different accounts.
 
-In a first request an event `AmountAdded` for the first account is fired and stored. The stored event gets id 1. In that request the projector now starts to update the amount of that account. But before that update completes, another request has already stored its own `AmountAdded` event for a second account. But because event 1 is not completed yet, the projector will not accept event 2. The projector is now out of sync: it will not accept new events until you've [replayed](laravel-event-projector/v1/replaying-events/replaying-events) all of them.
+In a first request an event `AmountAdded` for the first account is fired and stored. The stored event gets id 1. In that request the projector now starts to update the amount of that account. But before that update completes, another request has already stored its own `AmountAdded` event for a second account. But because event 1 is not completed yet, the projector will not accept event 2. The projector is now out of sync: it will not accept new events until you've [replayed](/laravel-event-projector/v1/replaying-events/replaying-events) all of them.
 
 If you think about it, the projector should perfectly be able to handle events related to the second account even if the projector hasn't handled the events that apply to the first account.
 


### PR DESCRIPTION
I've been enjoying the documentation thus far, thanks for introducing me to this wonderful pattern.

Here are some corrections
- Use the term "broke" instead of "broken" to be consistent with rest of the document.
- Add a missing space
- Fix reference to object containing the member `broke_mail_sent`

