### PR TITLE
Update storing-metadata.md

### DIFF
--- a/resources/views/laravel-event-projector/v1/advanced-usage/storing-metadata.md
+++ b/resources/views/laravel-event-projector/v1/advanced-usage/storing-metadata.md
@@ -19,10 +19,8 @@ class CustomStoredEvent extends StoredEvent
     {
         parent::boot();
         
-         static::created(function(CustomStoredEvent $storedEvent) {
+         static::creating(function(CustomStoredEvent $storedEvent) {
              $storedEvent->meta_data['user_id'] = auth()->user()->id;
-     
-             $storedEvent->save();
          });
     }
 }

--- a/resources/views/laravel-event-projector/v1/advanced-usage/storing-metadata.md
+++ b/resources/views/laravel-event-projector/v1/advanced-usage/storing-metadata.md
@@ -19,8 +19,8 @@ class CustomStoredEvent extends StoredEvent
     {
         parent::boot();
         
-         static::creating(function(CustomStoredEvent $storedEvent) {
-             $storedEvent->meta_data('user_id', auth()->user()->id);
+         static::created(function(CustomStoredEvent $storedEvent) {
+             $storedEvent->meta_data['user_id'] = auth()->user()->id;
      
              $storedEvent->save();
          });


### PR DESCRIPTION
Using the `creating` event results in an allowed memory exhausted error, while when using `created` we get the desired result. Also, calling meta_data() results in an undefined method. Looking at the code on line 61, the undefined method error can be fixed by using that same line.