### PR TITLE
Remove version

### DIFF
--- a/resources/views/laravel-medialibrary/v7/installation-setup.md
+++ b/resources/views/laravel-medialibrary/v7/installation-setup.md
@@ -5,7 +5,7 @@ title: Installation & setup
 Medialibrary can be installed via composer:
 
 ```bash
-composer require spatie/laravel-medialibrary:^7.0.0
+composer require spatie/laravel-medialibrary
 ```
 
 The package will automatically register a service provider.


### PR DESCRIPTION
^7.0.0 fails when using with Laravel 5.7.5

![image](https://user-images.githubusercontent.com/27734375/45926906-82df3d00-bf2a-11e8-83c5-9d8d0d03d9b0.png)
![image](https://user-images.githubusercontent.com/27734375/45926914-a2766580-bf2a-11e8-945b-130d4cd994d6.png)
![image](https://user-images.githubusercontent.com/27734375/45926918-b4f09f00-bf2a-11e8-9b93-1fec5ca34d1c.png)

