### PR TITLE
Send path to public_path function

### DIFF
--- a/resources/views/laravel-medialibrary/v6/installation-setup.md
+++ b/resources/views/laravel-medialibrary/v6/installation-setup.md
@@ -151,14 +151,14 @@ By default medialibrary will store it's files on Laravel's `public` disk. If you
 
         'media' => [
             'driver' => 'local',
-            'root'   => public_path().'/media',
+            'root'   => public_path('media'),
         ],
     ...
 ```
 
 Don't forget to ignore the directory of your configured disk so the files won't end up in your git repo.
 
-If you are planning on working with image manipulations it's recommended to configure a queue on your server and specify it in the config file. 
+If you are planning on working with image manipulations it's recommended to configure a queue on your server and specify it in the config file.
 
 Want to use S3? Then follow Laravel's instructions on [how to add the S3 Flysystem driver](https://laravel.com/docs/5.5/filesystem#configuration).
 

--- a/resources/views/laravel-medialibrary/v7/installation-setup.md
+++ b/resources/views/laravel-medialibrary/v7/installation-setup.md
@@ -151,7 +151,7 @@ By default medialibrary will store its files on Laravel's `public` disk. If you 
 
         'media' => [
             'driver' => 'local',
-            'root'   => public_path().'/media',
+            'root'   => public_path('media'),
         ],
     ...
 ```


### PR DESCRIPTION
This allows to maintain consistency with the declaration of this same page in v3 and v4 with the changes introduced in #47

P.S. It also removes a blank space left over only present in the v6 version.