### PR TITLE
Update thinking-in-events.md

### DIFF
--- a/resources/views/laravel-event-projector/v1/basic-usage/thinking-in-events.md
+++ b/resources/views/laravel-event-projector/v1/basic-usage/thinking-in-events.md
@@ -67,7 +67,6 @@ class BrokeReactor implements EventHandler
 
     public $handlesEvents = [
         MoneySubtracted::class => 'onMoneySubtracted',
-        BrokeMailSent::class => 'onBrokeMailSent',
     ];
 
     public function onMoneySubtracted(MoneySubtracted $event)
@@ -105,6 +104,12 @@ Let's leverage that new event in the `AccountBalanceProjector`.
 
 class AccountBalanceProjector implements Projector
 {
+    
+    protected $handlesEvents = [
+        // ..
+        BrokeMailSent::class => 'onBrokeMailSent',
+    ];
+    
     // ..
 
     public function onBrokeMailSent(BrokeMailSent $event)


### PR DESCRIPTION
The BrokeMailSent was left in the handlesEvents in the BrokeReactor.
In the example, in that step, the BrokeMailSent event is handled by the AccountBalanceProjector.