### PR TITLE
[Media Library] Mention save() when setting/removing custom properties

### DIFF
--- a/resources/views/laravel-medialibrary/v7/advanced-usage/using-custom-properties.md
+++ b/resources/views/laravel-medialibrary/v7/advanced-usage/using-custom-properties.md
@@ -24,6 +24,17 @@ $mediaItem->setCustomProperty('name', 'value'); // adds a new custom propery
 $mediaItem->forgetCustomProperty('name'); // removes a custom propery
 ```
 
+If you are setting or removing custom properties outside the process of adding media then you will need to persist/save these changes:
+
+```php
+$mediaItem = Media::find($id);
+
+$mediaItem->setCustomProperty('name', 'value'); // adds a new custom propery or updates an existing one
+$mediaItem->forgetCustomProperty('name'); // removes a custom propery
+
+$mediaItem->save();
+```
+
 You can also specify a default value when retrieving a custom property.
 
 ```php


### PR DESCRIPTION
The documentation doesn't currently mention that when setting or forgetting custom properties outside of adding media, that you need to call `save()` to persist the changes.

Actually took some time for me to investigate why my changes weren't persisting, and whilst it was a bit of a 🤦‍♂️ moment when I realised, I feel this is something that is worth mentioning in the docs.