### PR TITLE
Fixing url. Still pointing to laravel-uptime-monitor

### DIFF
--- a/resources/views/laravel-server-monitor/v1/monitoring-basics/notifications-and-events.md
+++ b/resources/views/laravel-server-monitor/v1/monitoring-basics/notifications-and-events.md
@@ -2,7 +2,7 @@
 title: Notifications and events
 ---
 
-The package notifies you if certain events take place when running checks on your server. You can specify which channels the notifications for certain events should be sent in the config file. If you don't want any notifications for a particular event, just pass an empty array. Out of the box `slack` and `mail` are supported. If you want to use another channel or modify the notifications, read the section on [customizing notifications](https://docs.spatie.be/laravel-uptime-monitor/v1/advanced-usage/customizing-notifications).
+The package notifies you if certain events take place when running checks on your server. You can specify which channels the notifications for certain events should be sent in the config file. If you don't want any notifications for a particular event, just pass an empty array. Out of the box `slack` and `mail` are supported. If you want to use another channel or modify the notifications, read the section on [customizing notifications](https://docs.spatie.be/laravel-server-monitor/v1/advanced-usage/customizing-notifications).
 
 ## Throttling notifications
 


### PR DESCRIPTION
Fixing url. Still pointing to laravel-uptime-monitor