### PR TITLE
Fixing transactions_count table name

### DIFF
--- a/resources/views/laravel-event-projector/v1/basic-usage/writing-your-first-projector.md
+++ b/resources/views/laravel-event-projector/v1/basic-usage/writing-your-first-projector.md
@@ -326,7 +326,7 @@ class CreateTransactionCountsTable extends Migration
 {
     public function up()
     {
-        Schema::create('transaction_counts', function (Blueprint $table) {
+        Schema::create('transactions_count', function (Blueprint $table) {
             $table->increments('id');
             $table->string('account_uuid');
             $table->integer('count')->default(0);
@@ -433,4 +433,4 @@ You'll notice that both projectors are immediately handling these new events. Th
 
 The cool thing about projectors is that you can write them after events have happened. Imagine that someone at the bank wants to have a report of the average balance of each account. You would be able to write a new projector, replay all events, and have that data.
 
-Projections are very fast to query. Imagine that our application has processed millions of events. If you want to create a screen where you display the accounts with the most transactions you can easily query the `transaction_counts` table. This way you don't need to fire off some expensive query. The projector will keep the projections (the `transaction_counts` table) up to date.
+Projections are very fast to query. Imagine that our application has processed millions of events. If you want to create a screen where you display the accounts with the most transactions you can easily query the `transactions_count` table. This way you don't need to fire off some expensive query. The projector will keep the projections (the `transactions_count` table) up to date.


### PR DESCRIPTION
When replaying the projector, the command is throwing an exception saying: relation "transactions_count" does not exist