### PR TITLE
Update Documentation about MongoDB auth options

### DIFF
--- a/resources/views/laravel-backup/v5/installation-and-setup.md
+++ b/resources/views/laravel-backup/v5/installation-and-setup.md
@@ -281,3 +281,19 @@ Here's an example for MySQL:
 		]  
 	],
 ```
+
+Mongodb often requires authentication on production servers and the standard uses an Authentication Database, normally `admin`, this is often set in the options of the mongodb connection in the `database.php` file in Laravel. **You Need to add an option to the `dump` config key to let db-dumper know the database**. 
+
+An Example of such a config in part is this for MongoDB: 
+```php
+mongodb' => [
+            'driver'   => 'mongodb',
+            ...,
+            'options'  => [
+                'database' => 'admin' // sets the authentication database required by mongo 3
+            ],
+            'dump' => [
+                'mongodb_user_auth' => 'admin' // your mongodb --authenticationDatabase option
+             ]  
+        ],
+```

--- a/resources/views/laravel-backup/v5/installation-and-setup.md
+++ b/resources/views/laravel-backup/v5/installation-and-setup.md
@@ -282,9 +282,8 @@ Here's an example for MySQL:
 	],
 ```
 
-Mongodb often requires authentication on production servers and the standard uses an Authentication Database, normally `admin`, this is often set in the options of the mongodb connection in the `database.php` file in Laravel. **You Need to add an option to the `dump` config key to let db-dumper know the database**. 
+Mongodb often requires authentication on production servers. By defeault it uses an authentication database. You can add the name of the admin database as an option to the `dump` config key in the connection definition. 
 
-An Example of such a config in part is this for MongoDB: 
 ```php
 //config/database.php
 'connections' => [

--- a/resources/views/laravel-backup/v5/installation-and-setup.md
+++ b/resources/views/laravel-backup/v5/installation-and-setup.md
@@ -286,14 +286,17 @@ Mongodb often requires authentication on production servers and the standard use
 
 An Example of such a config in part is this for MongoDB: 
 ```php
-mongodb' => [
-            'driver'   => 'mongodb',
-            ...,
-            'options'  => [
-                'database' => 'admin' // sets the authentication database required by mongo 3
-            ],
-            'dump' => [
-                'mongodb_user_auth' => 'admin' // your mongodb --authenticationDatabase option
-             ]  
-        ],
+//config/database.php
+'connections' => [
+	'mongodb' => [
+		    'driver'   => 'mongodb',
+		    ...,
+		    'options'  => [
+			'database' => 'admin' // sets the authentication database required by mongo 3
+		    ],
+		    'dump' => [
+			'mongodb_user_auth' => 'admin' // your mongodb --authenticationDatabase option
+		     ]  
+		],
+	],
 ```


### PR DESCRIPTION
This updates the documentation to mention that the `--authenticationDatabase` gets its value from `dump.mongodb_user_auth` in the connection configurations

This is not obvious from the documentation and also requires digging in the code to find this out.

Aside, does this mean lots of people are auth-ing in the database they connecting to, not using a normal setup or not authenticating at all ??