### PR TITLE
Download doesn't work 'properly'

### DIFF
--- a/resources/views/laravel-medialibrary/v7/downloading-media/downloading-a-single-file.md
+++ b/resources/views/laravel-medialibrary/v7/downloading-media/downloading-a-single-file.md
@@ -25,7 +25,7 @@ class DownloadMediaController
 {
    public function show(Media $mediaItem)
    {
-       return response()->download($mediaItem->getPath(), $mediaItem->name);
+       return response()->download($mediaItem->getPath(), $mediaItem->file_name);
    }
 }
 ```


### PR DESCRIPTION
When downloading a docx file it doesn't work on windows and mac (tested on Chrome) because the file name is invalid and doesn't include a .docx in the file name. Because of this you can't open the file.