### PR TITLE
Fix typo for Laravel Event Projector, Replaying Events

### DIFF
--- a/resources/views/laravel-event-projector/v2/using-projectors/replaying-events.md
+++ b/resources/views/laravel-event-projector/v2/using-projectors/replaying-events.md
@@ -12,7 +12,7 @@ All [events](/laravel-event-projector/v2/handling-events/preparing-events) that 
  php artisan event-projector:replay
  ```
 
- You can also projectors by using the `--projector` option. All stored events will be passed only to that projector.
+ You can also specify projectors by using the `--projector` option. All stored events will be passed only to that projector.
 
  ```bash
   php artisan event-projector:replay --projector=App\\Projectors\\AccountBalanceProjector


### PR DESCRIPTION
https://docs.spatie.be/laravel-event-projector/v2/using-projectors/replaying-events

> You can also projectors by using the --projector option. All stored events will be passed only to that projector.

... has been changed to:

> You can also specify projectors by using the --projector option. All stored events will be passed only to that projector.