### PR TITLE
remove outdated version from require

### DIFF
--- a/resources/views/laravel-event-projector/v2/installation-setup.md
+++ b/resources/views/laravel-event-projector/v2/installation-setup.md
@@ -5,7 +5,7 @@ title: Installation & setup
 laravel-event-projector can be installed via composer:
 
 ```bash
-composer require spatie/laravel-event-projector:^2.0.0
+composer require spatie/laravel-event-projector
 ```
 
 You need to publish and run the migrations to create the `stored_events` table:


### PR DESCRIPTION
I suppose it would be better to not have the code-snippet require an outdated version ^2.0.0.

Even more so, as the documentation mentions autodiscovery and make:projector, both not working (?) in 2.0.0, and also features code-snippets from a later version (e.g. config).