### PR TITLE
Add missing links

### DIFF
--- a/resources/views/laravel-event-projector/v2/installation-setup.md
+++ b/resources/views/laravel-event-projector/v2/installation-setup.md
@@ -104,6 +104,6 @@ return [
 ];
 ```
 
-The package will scan all classes of your project to [automatically discover projectors and reactors](#TODO:add link). In a production production environment you problably should [cache auto discovered projectors and reactors](TODO: add link).
+The package will scan all classes of your project to [automatically discover projectors and reactors](/laravel-event-projector/v2/advanced-usage/discovering-projectors-and-reactors#discovering-projectors-and-reactors). In a production production environment you problably should [cache auto discovered projectors and reactors](/laravel-event-projector/v2/advanced-usage/discovering-projectors-and-reactors#caching-discovered-projectors-and-reactors).
 
 It's recommended that should set up a queue. Specify the connection name in the `queue` key of the `event-projector` config file. This queue will be used to guarantee that the events will be processed by all projectors in the right order. You should make sure that the queue will process only one job at a time. In a local environment, where events have a very low chance of getting fired concurrently, it's probably ok to just use the `sync` driver.


### PR DESCRIPTION
I saw two `#TODO`'s for inserting a link, and based on the already given names I assumed where they should link to.